### PR TITLE
feat: add plausible

### DIFF
--- a/static/layouts/_default/baseof.html
+++ b/static/layouts/_default/baseof.html
@@ -69,5 +69,10 @@
     {{ with resources.Get "js/script.js" }}
     <script src="{{ .RelPermalink}}"></script>
     {{ end }}
+    <script
+      defer
+      data-domain="iarbre.fr"
+      src="https://plausible.io/js/script.outbound-links.js"
+    ></script>
   </body>
 </html>


### PR DESCRIPTION
Simplement un ajout de plausible pour pouvoir tracker le nombre de visiteur·euses sur le site, sans avoir besoin de recueil de consentement.

Resolve #44 