### PR TITLE
draft: feat: display score popup on click

### DIFF
--- a/front/cypress/components/MapScorePopup.cy.ts
+++ b/front/cypress/components/MapScorePopup.cy.ts
@@ -1,0 +1,13 @@
+import MapScorePopup from "@/components/map/MapScorePopup.vue"
+
+describe("Component:MapScorePopup", () => {
+  it("renders correctly", () => {
+    cy.mount(MapScorePopup, {
+      props: {
+        score: 8,
+        lat: 45.75773479280862,
+        lng: 4.8537684279176645
+      }
+    })
+  })
+})

--- a/front/cypress/support/component.ts
+++ b/front/cypress/support/component.ts
@@ -21,6 +21,8 @@ import "./commands"
 
 import { mount } from "cypress/vue"
 
+import "../../src/assets/styles/main.sass"
+
 // Augment the Cypress namespace to include type definitions for
 // your custom command.
 // Alternatively, can be defined in cypress/support/component.d.ts

--- a/front/src/assets/styles/_iarbre.sass
+++ b/front/src/assets/styles/_iarbre.sass
@@ -23,3 +23,17 @@ $scale-4: #ccc688
 $scale-6: #b7d98f
 $scale-8: #72bc71
 $scale-10: #026838
+
+.button
+  font-family: $accent-font
+  border: none
+  padding: 10px 20px
+  border-radius: 50px
+  text-decoration: none
+
+  &.primary
+    color: $white
+    background-color: $dark-green
+
+.text-light-green
+  color: $light-green

--- a/front/src/components/map/MapScorePopup.vue
+++ b/front/src/components/map/MapScorePopup.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import ScoreLabel from "./ScoreLabel.vue"
+import { computed } from "vue"
+
+const props = defineProps({
+  score: {
+    required: true,
+    type: Number
+  },
+  lat: {
+    required: true,
+    type: Number
+  },
+  lng: {
+    required: true,
+    type: Number
+  }
+})
+
+const label = computed(() => {
+  if (props.score >= 5) return "Plantabilité élevée"
+  else return "Plantabilité faible"
+})
+</script>
+
+<template>
+  <div class="popover">
+    <div class="columns">
+      <div class="left">
+        <score-label :score="4" label="4/10" size="huge" />
+      </div>
+      <div class="right">
+        <h3 class="title">{{ label }}</h3>
+        <button class="button primary">Voir les détails</button>
+      </div>
+    </div>
+    <div class="text-light-green">{{ lat }}° N, {{ lng }}° E <button>(copy)</button></div>
+  </div>
+</template>
+
+<style lang="sass" scoped>
+.popover
+    padding: 10px
+
+    .columns
+        .left
+            flex-grow: 1
+
+        .right
+            flex-grow: 2
+
+        display: flex
+        flex-direction: row
+
+
+.title
+    font: $accent-font
+</style>

--- a/front/src/components/map/PlantabiliteLegend.vue
+++ b/front/src/components/map/PlantabiliteLegend.vue
@@ -1,25 +1,25 @@
+<script setup lang="ts">
+import ScoreLabel from "./ScoreLabel.vue"
+</script>
+
 <template>
   <div class="plantabilite-legend">
     <span class="plantabilite-legend-text">Non plantable</span>
     <div class="is-flex">
-      <div
+      <score-label
         v-for="index in [0, 2, 4, 6, 8, 10]"
         :key="index"
-        class="plantabilite-legend-scale hexagon"
-        :class="{ ['scale-' + index]: true }"
-      >
-        <span>{{ index }}</span>
-      </div>
+        class="plantabilite-legend-scale"
+        :score="index"
+        :label="`${index}`"
+        size="small"
+      />
     </div>
     <span class="plantabilite-legend-text">Plantable</span>
   </div>
 </template>
 
 <style lang="sass" scoped>
-
-$hexagon-width: 12px
-
-
 .plantabilite-legend
   font-family: $accent-font
   display: flex
@@ -37,81 +37,6 @@ $hexagon-width: 12px
     display: flex
     align-items: center
     justify-content: center
-    width: 25px
-    height: 20px
-    color: white
-    font-size: 1.3em
-
-  .hexagon
-    &.scale-0
-      background-color: $scale-0
-      color: $brown
-      &::before
-        border-bottom-color: $scale-0
-      &::after
-        border-top-color: $scale-0
-    &.scale-2
-      background-color: $scale-2
-      color: $brown
-      &::before
-        border-bottom-color: $scale-2
-      &::after
-        border-top-color: $scale-2
-
-    &.scale-4
-      background-color: $scale-4
-      color: $brown
-      &::before
-        border-bottom-color: $scale-4
-      &::after
-        border-top-color: $scale-4
-
-    &.scale-6
-      color: $brown
-      background-color: $scale-6
-      &::before
-        border-bottom-color: $scale-6
-      &::after
-        border-top-color: $scale-6
-
-    &.scale-8
-      color: $brown
-      background-color: $scale-8
-      &::before
-        border-bottom-color: $scale-8
-      &::after
-        border-top-color: $scale-8
-
-    &.scale-10
-      background-color: $scale-10
-      &::before
-        border-bottom-color: $scale-10
-      &::after
-        border-top-color: $scale-10
-
-    position: relative
-    height: calc(sqrt(3) * $hexagon-width)
-    width: calc(3 * $hexagon-width)
-    margin: 5px
-
-    &::before
-      content: ""
-      position: absolute
-      width: 0
-      border-left: calc(1.5 * $hexagon-width) solid transparent
-      border-right: calc(1.5 * $hexagon-width) solid transparent
-      bottom: 100%
-      border-bottom: calc(sqrt(3) / 2 * $hexagon-width) solid red
-
-    &::after
-      content: ""
-      position: absolute
-      width: 0
-      border-left: calc(1.5 * $hexagon-width) solid transparent
-      border-right: calc(1.5 * $hexagon-width) solid transparent
-      top: 100%
-      width: 0
-      border-top: calc(sqrt(3) / 2 * $hexagon-width) solid #007BFF
 
   .plantabilite-legend-text
     font-size: 0.9rem

--- a/front/src/components/map/ScoreLabel.vue
+++ b/front/src/components/map/ScoreLabel.vue
@@ -1,0 +1,117 @@
+<script setup lang="ts">
+const props = defineProps({
+  score: {
+    required: true,
+    type: Number
+  },
+  label: {
+    required: true,
+    type: String
+  },
+  size: {
+    required: true,
+    type: String
+  }
+})
+</script>
+
+<template>
+  <div class="hexagon" :class="{ [`scale-${score}`]: true, [size]: true }">
+    <span>{{ label }}</span>
+  </div>
+</template>
+
+<style lang="sass" scoped>
+
+$hexagons-width: ("small": 12px, "huge": 30px)
+
+.hexagon
+    @each $name, $hexagon-width in $hexagons-width
+        &.#{$name}
+            height: calc(sqrt(3) * $hexagon-width)
+            width: calc(3 * $hexagon-width)
+            margin-top: calc($hexagon-width + 5px)
+            margin-bottom: calc($hexagon-width + 5px)
+
+            &::before
+                border-left: calc(1.5 * $hexagon-width) solid transparent
+                border-right: calc(1.5 * $hexagon-width) solid transparent
+                border-bottom: calc(sqrt(3) / 2 * $hexagon-width) solid red
+
+            &::after
+                border-left: calc(1.5 * $hexagon-width) solid transparent
+                border-right: calc(1.5 * $hexagon-width) solid transparent
+                border-top: calc(sqrt(3) / 2 * $hexagon-width) solid #007BFF
+
+    &.scale-0
+        background-color: $scale-0
+        color: $brown
+        &::before
+            border-bottom-color: $scale-0
+        &::after
+            border-top-color: $scale-0
+    &.scale-2
+        background-color: $scale-2
+        color: $brown
+        &::before
+            border-bottom-color: $scale-2
+        &::after
+            border-top-color: $scale-2
+
+    &.scale-4
+        background-color: $scale-4
+        color: $brown
+        &::before
+            border-bottom-color: $scale-4
+        &::after
+            border-top-color: $scale-4
+
+    &.scale-6
+        color: $brown
+        background-color: $scale-6
+        &::before
+            border-bottom-color: $scale-6
+        &::after
+            border-top-color: $scale-6
+
+    &.scale-8
+        color: $brown
+        background-color: $scale-8
+        &::before
+            border-bottom-color: $scale-8
+        &::after
+            border-top-color: $scale-8
+
+    &.scale-10
+        background-color: $scale-10
+        color: $white
+        &::before
+            border-bottom-color: $scale-10
+        &::after
+            border-top-color: $scale-10
+
+    position: relative
+    margin: 5px
+    display: block
+    text-align: center
+
+    &::before
+        content: ""
+        position: absolute
+        width: 0
+        bottom: 100%
+        left: 0
+
+    &::after
+        content: ""
+        position: absolute
+        left: 0
+        top: 100%
+        width: 0
+
+    &.huge
+        font-size: 2.7rem
+
+    &.small
+        font-size: 1.3rem
+</style>

--- a/front/src/main.ts
+++ b/front/src/main.ts
@@ -1,4 +1,5 @@
 import "./assets/styles/main.sass"
+import "maplibre-gl/dist/maplibre-gl.css"
 
 import { createApp } from "vue"
 import { createPinia } from "pinia"

--- a/front/src/stores/map.ts
+++ b/front/src/stores/map.ts
@@ -1,8 +1,10 @@
-import { computed, ref } from "vue"
+import { computed, ref, createApp, h } from "vue"
 import { defineStore } from "pinia"
-import { Map } from "maplibre-gl"
+import { Map, Popup } from "maplibre-gl"
 import { FULL_BASE_API_URL, MIN_ZOOM } from "@/utils/constants"
 import { ModelType } from "@/utils/enum"
+import MapScorePopup from "@/components/map/MapScorePopup.vue"
+
 export const useMapStore = defineStore("map", () => {
   const mapInstancesByIds = ref<Record<string, Map>>({})
 
@@ -30,6 +32,24 @@ export const useMapStore = defineStore("map", () => {
         "fill-color": ["get", "color"],
         "fill-opacity": 0.6
       }
+    })
+
+    map.on("click", layerId, (e) => {
+      const ScorePopupApp = createApp({
+        setup() {
+          return () => h(MapScorePopup, { score: 4, lat: e.lngLat.lat, lng: e.lngLat.lng })
+        }
+      })
+      const wrapper = document.createElement("div")
+      ScorePopupApp.mount(wrapper)
+      document.body.appendChild(wrapper)
+
+      // console.log(wrapper.innerHTML)
+      new Popup()
+        .setLngLat(e.lngLat)
+        .setHTML(wrapper.innerHTML)
+        // .setHTML("<p>boom</p>")
+        .addTo(map)
     })
   }
 


### PR DESCRIPTION
Specs :
* Refacto : déplacement "du score dans un hexagone" dans un composant dédié pour être réutilisé ;
* Ajout d'une popup avec le bon wireframe avec le bon score au clic
* Possibilité de copier les coordonnées GPS au clic
