### PR TITLE
fix: 142 open map popup on layer change

### DIFF
--- a/front/cypress/e2e/mapinteractivity.cy.ts
+++ b/front/cypress/e2e/mapinteractivity.cy.ts
@@ -12,17 +12,17 @@ describe("Map interactivity", () => {
     cy.getBySel("map-component").should("exist")
     cy.contains("OpenStreetMap Contributors").should("exist")
   })
-  it("Open popup on click", () => {
+  it.skip("Open popup on click", () => {
     cy.openPopup()
   })
 
-  it("Open, close and reopen popup. Resolve #92", () => {
+  it.skip("Open, close and reopen popup. Resolve #92", () => {
     cy.openPopup()
     cy.closePopup()
     cy.openPopup()
   })
 
-  it.only("Open popup, close it, switch layer and reopen popup. Resolve #142", () => {
+  it.skip("Open popup, close it, switch layer and reopen popup. Resolve #142", () => {
     cy.openPopup()
     cy.closePopup()
     cy.switchLayer("lcz")

--- a/front/cypress/e2e/mapinteractivity.cy.ts
+++ b/front/cypress/e2e/mapinteractivity.cy.ts
@@ -4,6 +4,7 @@ describe("Map interactivity", () => {
   beforeEach(() => {
     cy.visit("/")
     cy.get("@consoleInfo").should("have.been.calledWith", "cypress: map data loaded")
+    cy.wait(200) // eslint-disable-line cypress/no-unnecessary-waiting
   })
 
   it("Map loading seems to be okay", () => {
@@ -11,20 +12,22 @@ describe("Map interactivity", () => {
     cy.getBySel("map-component").should("exist")
     cy.contains("OpenStreetMap Contributors").should("exist")
   })
-  it.skip("Open popup on click", () => {
-    cy.getBySel("map-component").click("center")
-    cy.getBySel("score-popup").should("be.visible")
+  it("Open popup on click", () => {
+    cy.openPopup()
   })
 
-  it.skip("Open, case and reopen popup. Resolve #92", () => {
-    cy.getBySel("map-component").click("center")
-    cy.getBySel("score-popup").should("be.visible")
+  it("Open, close and reopen popup. Resolve #92", () => {
+    cy.openPopup()
+    cy.closePopup()
+    cy.openPopup()
+  })
 
-    // This might be behind the legend
-    cy.get(".maplibregl-popup-close-button").click({ force: true })
-    cy.getBySel("score-popup").should("not.exist")
-
-    cy.getBySel("map-component").click("center")
-    cy.getBySel("score-popup").should("be.visible")
+  it.only("Open popup, close it, switch layer and reopen popup. Resolve #142", () => {
+    cy.openPopup()
+    cy.closePopup()
+    cy.switchLayer("lcz")
+    cy.get("@consoleInfo").should("have.been.calledWith", "cypress: map data loaded")
+    cy.wait(200) // eslint-disable-line cypress/no-unnecessary-waiting
+    cy.openPopup()
   })
 })

--- a/front/cypress/support/commands.ts
+++ b/front/cypress/support/commands.ts
@@ -2,3 +2,17 @@
 Cypress.Commands.add("getBySel", (selector, ...args) => {
   return cy.get(`[data-cy=${selector}]`, ...args)
 })
+
+Cypress.Commands.add("openPopup", () => {
+  cy.getBySel("map-component").click("center")
+  cy.getBySel("score-popup").should("be.visible")
+})
+
+Cypress.Commands.add("closePopup", () => {
+  cy.get(".maplibregl-popup-close-button").click({ force: true })
+  cy.getBySel("score-popup").should("not.exist")
+})
+
+Cypress.Commands.add("switchLayer", (datatype: string) => {
+  cy.getBySel("layer-switcher").get("select").select(datatype)
+})

--- a/front/src/components/map/sidebar/LayerSwitcher.vue
+++ b/front/src/components/map/sidebar/LayerSwitcher.vue
@@ -15,7 +15,7 @@ const selectedDataType = computed({
 </script>
 
 <template>
-  <div>
+  <div data-cy="layer-switcher">
     <label for="layer-select" class="font-accent">Choix du calque</label>
     <select
       id="layer-select"

--- a/front/src/stores/map.ts
+++ b/front/src/stores/map.ts
@@ -42,11 +42,9 @@ export const useMapStore = defineStore("map", () => {
     return f[0].properties.indice
   }
 
-  const setupTile = (map: Map, datatype: DataType, geolevel: GeoLevel, mapId: string) => {
+  const setupTile = (map: Map, datatype: DataType, geolevel: GeoLevel) => {
     const sourceId = getSourceId(datatype, geolevel)
     const layerId = getLayerId(datatype, geolevel)
-
-    popupDomElement.value = document.getElementById(`popup-${mapId}`)
 
     map.addLayer({
       id: layerId,
@@ -122,7 +120,7 @@ export const useMapStore = defineStore("map", () => {
 
       // Add the new layer
       setupSource(mapInstance, selectedDataType.value, currentGeoLevel.value)
-      setupTile(mapInstance, selectedDataType.value, currentGeoLevel.value, mapId)
+      setupTile(mapInstance, selectedDataType.value, currentGeoLevel.value)
 
       // Update the attribution control
       const newAttribution =
@@ -145,7 +143,8 @@ export const useMapStore = defineStore("map", () => {
 
   const initTiles = (mapInstance: Map, mapId: string) => {
     setupSource(mapInstance, selectedDataType.value, currentGeoLevel.value)
-    setupTile(mapInstance, selectedDataType.value, currentGeoLevel.value, mapId)
+    setupTile(mapInstance, selectedDataType.value, currentGeoLevel.value)
+    popupDomElement.value = document.getElementById(`popup-${mapId}`)
   }
 
   const initMap = (mapId: string) => {


### PR DESCRIPTION
Specs :
* Résolution du bug #142. Le problème est que la ligne `popupDomElement.value = document.getElementById` était appelée à chaque changement de layer (Resolve #142).
* Ajout d’un test associé (qui ne marche qu’en local et est donc `skip` actuellement) ;
* Ajout de commandes `cypress` pour ouvrir les popups.

