### PR TITLE
feat(front): add context for plantability with zoom < 17

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,32 @@
+language: "en-US"
+
+reviews:
+  profile: "assertive"
+  high_level_summary: false
+  commit_status: false
+  changed_files_summary: false
+  sequence_diagrams: false
+  estimate_code_review_effort: false
+  suggested_labels: false
+  suggested_reviewers: false
+
+  auto_review:
+    enabled: false
+    drafts: false
+    ignore_title_keywords:
+      - "wip"
+      - "draft"
+
+  pre_merge_checks:
+  docstrings:
+    mode: "off"
+
+chat:
+  art: false
+  auto_reply: false
+
+knowledge_base:
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "./CODING_STANDARDS.md"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -9,17 +9,11 @@ reviews:
   estimate_code_review_effort: false
   suggested_labels: false
   suggested_reviewers: false
+  poem: false
 
   auto_review:
     enabled: false
     drafts: false
-    ignore_title_keywords:
-      - "wip"
-      - "draft"
-
-  pre_merge_checks:
-  docstrings:
-    mode: "off"
 
 chat:
   art: false

--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -1,0 +1,475 @@
+# 🌳 iArbre Coding Standards
+
+This document outlines the coding standards and conventions used in the iArbre project to ensure consistency, maintainability, and code quality across both backend (Django/Python) and frontend (Vue.js/TypeScript) components.
+
+## 📋 Table of Contents
+
+- [General Principles](#general-principles)
+- [Project Structure](#project-structure)
+- [Backend Standards (Django/Python)](#backend-standards-djangopython)
+- [Frontend Standards (Vue.js/TypeScript)](#frontend-standards-vuejstypescript)
+- [Geographic/GIS Standards](#geographicgis-standards)
+- [Testing Standards](#testing-standards)
+- [Git & Development Workflow](#git--development-workflow)
+- [Documentation](#documentation)
+
+## 🎯 General Principles
+
+### Code Quality
+
+- **Readability First**: Code should be self-documenting and easy to understand
+- **Consistency**: Follow established patterns within the codebase
+- **DRY (Don't Repeat Yourself)**: Avoid code duplication through proper abstraction
+- **SOLID Principles**: Apply SOLID principles where appropriate
+- **Security**: Never commit secrets, keys, or sensitive information
+
+### Naming Conventions
+
+- Use descriptive and meaningful names for variables, functions, and classes
+- Avoid abbreviations unless they are widely understood
+- Be consistent with naming patterns within each language/framework
+
+## 📁 Project Structure
+
+```
+iarbre-back/
+├── back/                 # Django backend
+│   ├── api/             # API endpoints and views
+│   ├── iarbre_data/     # Main Django app with models
+│   ├── plantability/    # Plantability calculations
+│   └── requirements.txt # Python dependencies
+├── front/               # Vue.js frontend
+│   ├── src/
+│   │   ├── components/  # Vue components
+│   │   ├── composables/ # Reusable logic
+│   │   ├── stores/      # Pinia state management
+│   │   ├── types/       # TypeScript type definitions
+│   │   └── utils/       # Utility functions
+│   └── package.json     # Node.js dependencies
+├── docs/                # MkDocs documentation
+├── deploy/              # Ansible deployment scripts
+└── static/              # Static website
+```
+
+## 🐍 Backend Standards (Django/Python)
+
+### File Organization
+
+- **Separate concerns**: Use separate directories for `views/`, `serializers/`, `tests/`
+- **Model organization**: Keep related models in the same app
+- **Management commands**: Place custom commands in `management/commands/`
+
+### Python Code Style
+
+- **PEP 8 compliance**: Follow Python PEP 8 style guidelines
+- **Line length**: Maximum 88 characters (Black formatter default)
+- **Import organization**:
+
+  ```python
+  # Standard library imports
+  from django.db import models
+  from django.contrib.gis.db.models import PolygonField
+
+  # Third-party imports
+  from rest_framework import serializers
+
+  # Local imports
+  from api.constants import GeoLevel, DataType
+  ```
+
+### Django Patterns
+
+#### Models
+
+```python
+class Tile(models.Model):
+    """Elementary element on the map with the value of the indice."""
+
+    geometry = PolygonField(srid=2154)
+    map_geometry = PolygonField(srid=TARGET_MAP_PROJ, null=True, blank=True)
+    plantability_indice = models.FloatField(null=True)
+
+    def get_layer_properties(self):
+        """Return the properties of the tile for the MVT datatype."""
+        return {
+            "id": self.id,
+            "indice": self.plantability_normalized_indice,
+        }
+```
+
+#### Views
+
+```python
+class TileView(generics.RetrieveAPIView):
+    @method_decorator(cache_page(60 * 60 * 24))
+    def get(self, request, *args, **kwargs):
+        try:
+            return HttpResponse(
+                self.get_object().mvt_file,
+                content_type="application/x-protobuf"
+            )
+        except MVTTile.DoesNotExist:
+            raise Http404
+```
+
+#### Serializers
+
+```python
+class TileSerializer(serializers.ModelSerializer):
+    details = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Tile
+        fields = (
+            "id",
+            "plantability_normalized_indice",
+            "details",
+        )
+
+    def get_details(self, obj):
+        """Parse JSON string details if needed."""
+        if isinstance(obj.details, str):
+            try:
+                return json.loads(obj.details)
+            except json.JSONDecodeError:
+                return None
+        return obj.details
+```
+
+### Constants and Enums
+
+```python
+class GeoLevel(TextChoices):
+    TILE = "tile", "Tile"
+    CITY = "city", "City"
+    IRIS = "iris", "Iris"
+
+DEFAULT_ZOOM_LEVELS = (10, 18)
+ZOOM_TO_GRID_SIZE = {10: 100, 11: 75, 12: 75}
+```
+
+### Error Handling
+
+- Use appropriate Django/DRF exceptions
+- Provide meaningful error messages
+- Log errors appropriately for debugging
+
+## 🌟 Frontend Standards (Vue.js/TypeScript)
+
+### File Naming Conventions
+
+- **Components**: PascalCase (`MapContextData.vue`)
+- **Composables**: camelCase with `use` prefix (`useMapFilters.ts`)
+- **Utilities**: camelCase (`enum.ts`, `constants.ts`)
+- **Types**: camelCase (`map.ts`, `plantability.ts`)
+
+### Vue Component Structure
+
+```vue
+<script lang="ts" setup>
+import { useMapStore } from "@/stores/map";
+import { DataType } from "@/utils/enum";
+import type { PlantabilityData } from "@/types/plantability";
+
+const mapStore = useMapStore();
+
+defineProps({
+  fullHeight: {
+    type: Boolean,
+    default: false,
+  },
+});
+</script>
+
+<template>
+  <div class="map-context-data-container w-full" data-cy="map-context-data">
+    <map-context-data-plantability
+      v-if="mapStore.selectedDataType === DataType.PLANTABILITY"
+      :data="mapStore.contextData.data as PlantabilityData"
+    />
+  </div>
+</template>
+```
+
+### TypeScript Patterns
+
+#### Type Definitions
+
+```typescript
+export interface MapScorePopupData {
+  lng: number;
+  lat: number;
+  id: string;
+  properties: any;
+  score: string;
+}
+
+export interface MapParams {
+  lng: number;
+  lat: number;
+  zoom: number;
+  dataType: DataType | null;
+}
+```
+
+#### Enums
+
+```typescript
+export enum DataType {
+  PLANTABILITY = "plantability",
+  VULNERABILITY = "vulnerability",
+  CLIMATE_ZONE = "lcz",
+}
+
+export const DataTypeToLabel: Record<DataType, string> = {
+  [DataType.PLANTABILITY]: "🌳 Score de plantabilité",
+  [DataType.CLIMATE_ZONE]: "🌆 Zones climatiques locales",
+  [DataType.VULNERABILITY]: "🌡️ Vulnérabilité chaleur",
+};
+```
+
+#### Composables
+
+```typescript
+export function useMapFilters() {
+  const filteredValues = ref<(number | string)[]>([]);
+
+  const hasActiveFilters = computed(() => filteredValues.value.length > 0);
+  const activeFiltersCount = computed(() => filteredValues.value.length);
+
+  const toggleFilter = (value: number | string) => {
+    const index = filteredValues.value.indexOf(value);
+    if (index > -1) {
+      filteredValues.value.splice(index, 1);
+    } else {
+      filteredValues.value.push(value);
+    }
+  };
+
+  return {
+    filteredValues,
+    toggleFilter,
+    hasActiveFilters,
+    activeFiltersCount,
+  };
+}
+```
+
+### State Management (Pinia)
+
+```typescript
+export const useMapStore = defineStore("map", () => {
+  const selectedDataType = ref<DataType>(DataType.PLANTABILITY);
+  const currentZoom = ref<number>(14);
+
+  return {
+    selectedDataType,
+    currentZoom,
+  };
+});
+```
+
+### CSS/Styling
+
+- **Tailwind CSS**: Use Tailwind utility classes for styling
+- **PrimeVue**: Use PrimeVue components for UI elements
+- **Component scoping**: Avoid global styles, scope styles to components
+
+## 🗺️ Geographic/GIS Standards
+
+### Coordinate Systems
+
+- **Storage**: Use SRID 2154 (Lambert 93) for data storage in PostGIS
+- **Display**: Transform to Web Mercator (SRID 3857) for map display
+- **API responses**: Include both `geometry` and `map_geometry` fields
+
+### Spatial Data Handling
+
+```python
+# Models with spatial fields
+class Tile(models.Model):
+    geometry = PolygonField(srid=2154)  # Storage projection
+    map_geometry = PolygonField(srid=TARGET_MAP_PROJ, null=True, blank=True)  # Display projection
+
+# Automatic geometry transformation
+@receiver(pre_save, sender=Tile)
+def before_save(sender, instance, **kwargs):
+    if instance.map_geometry is None:
+        instance.map_geometry = instance.geometry.transform(TARGET_MAP_PROJ, clone=True)
+```
+
+### MVT (Mapbox Vector Tiles)
+
+- Store MVT files using Django FileField
+- Implement caching for tile endpoints
+- Use proper MIME type: `application/x-protobuf`
+
+## 🧪 Testing Standards
+
+### Backend Testing (Django)
+
+```python
+class TileViewTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+        # Create test data
+        square = Polygon(((0, 0), (1, 0), (1, 1), (0, 1), (0, 0)), srid=2154)
+        self.tile = Tile.objects.create(geometry=square)
+
+    def test_valid_tile_retrieval(self):
+        url = "/api/tiles/city/test/10/512/256.mvt"
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["content-type"], "application/x-protobuf")
+```
+
+### Frontend Testing
+
+#### Unit Tests (Vitest)
+
+```typescript
+import { test, expect } from "vitest";
+
+test("toggleFilter adds and removes values", () => {
+  const { filteredValues, toggleFilter } = useMapFilters();
+
+  toggleFilter("test");
+  expect(filteredValues.value).toContain("test");
+
+  toggleFilter("test");
+  expect(filteredValues.value).not.toContain("test");
+});
+```
+
+#### E2E Tests (Cypress)
+
+```typescript
+describe("Map", () => {
+  beforeEach(() => {
+    cy.visit("/plantability/13/45.07126/5.5543");
+  });
+
+  it("loads with plantability layer", () => {
+    cy.getBySel("plantability-legend").should("exist");
+    cy.getBySel("map-component").should("exist");
+  });
+});
+```
+
+### Test Data Attributes
+
+- Use `data-cy` attributes for Cypress selectors
+- Keep test data separate from production data
+- Mock external APIs in tests
+
+## 🔄 Git & Development Workflow
+
+### Branch Naming
+
+- **Feature branches**: `feature/description` or `feat/description`
+- **Bug fixes**: `fix/issue-description`
+- **Hotfixes**: `hotfix/description`
+
+### Commit Messages
+
+- Use conventional commit format when possible
+- Be descriptive and concise
+- Reference issue numbers when applicable
+
+```
+feat: add vulnerability filtering by day/night mode
+
+- Add vulnerability mode toggle in UI
+- Implement filtering logic in useMapFilters composable
+- Update map layer rendering based on selected mode
+
+Closes #123
+```
+
+### Pre-commit Hooks
+
+- **Python**: Black, isort, flake8
+- **JavaScript/TypeScript**: ESLint, Prettier
+- **General**: File formatting, trailing whitespace
+
+### Pull Request Guidelines
+
+- Provide clear description of changes
+- Include screenshots for UI changes
+- Ensure all tests pass
+- Request appropriate reviewers
+
+## 📚 Documentation
+
+### Code Documentation
+
+- **Python**: Use docstrings for classes and functions
+- **TypeScript**: Use JSDoc comments for complex functions
+- **API**: Document endpoints with proper HTTP status codes
+
+### README Files
+
+- Each major component should have a README
+- Include setup instructions and examples
+- Keep documentation up to date
+
+### Comments
+
+- Use comments sparingly - prefer self-documenting code
+- Explain **why**, not **what**
+- Remove commented-out code before committing
+
+## 🔧 Tools and Configuration
+
+### Development Tools
+
+- **Backend**: Django, PostgreSQL with PostGIS, pytest
+- **Frontend**: Vue 3, TypeScript, Vite, Vitest, Cypress
+- **Linting**: ESLint, Prettier, Black, isort
+- **Documentation**: MkDocs
+
+### IDE Configuration
+
+- Configure your IDE to use the project's linting rules
+- Set up format-on-save for consistent code formatting
+- Use appropriate extensions for Django and Vue development
+
+## 🚀 Performance Considerations
+
+### Backend Performance
+
+- Use database indexes appropriately
+- Implement caching for expensive operations
+- Optimize spatial queries with proper SRID usage
+
+### Frontend Performance
+
+- Lazy load components when appropriate
+- Use computed properties for expensive calculations
+- Implement proper error boundaries
+
+## 🔒 Security Guidelines
+
+### Backend Security
+
+- Never commit secrets or API keys
+- Use environment variables for configuration
+- Implement proper authentication and authorization
+- Validate and sanitize all inputs
+
+### Frontend Security
+
+- Sanitize user inputs
+- Use HTTPS for all API calls
+- Implement proper error handling to avoid information leakage
+
+---
+
+## 📝 Conclusion
+
+These coding standards are living guidelines that should evolve with the project. When in doubt, follow the existing patterns in the codebase and discuss proposed changes with the team.
+
+For questions or suggestions about these standards, please open an issue or discussion in the project repository.
+
+**Remember**: The goal is to write code that is readable, maintainable, and follows the established patterns of the iArbre project. Consistency is key! 🌳

--- a/front/components.d.ts
+++ b/front/components.d.ts
@@ -10,6 +10,7 @@ declare module 'vue' {
   export interface GlobalComponents {
     AppDrawer: typeof import('./src/components/AppDrawer.vue')['default']
     Button: typeof import('primevue/button')['default']
+    Chart: typeof import('primevue/chart')['default']
     Chip: typeof import('primevue/chip')['default']
     CircularProgress: typeof import('./src/components/progress/CircularProgress.vue')['default']
     ClimateContextDataMetrics: typeof import('./src/components/contextData/climate/ClimateContextDataMetrics.vue')['default']

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -12,6 +12,7 @@
         "@primeuix/themes": "^1.0.3",
         "@tailwindcss/vite": "^4.0.17",
         "@vue/test-utils": "^2.4.6",
+        "chart.js": "^4.5.0",
         "jsdom": "^26.1.0",
         "maplibre-gl": "^5.4.0",
         "pinia": "^3.0.0",
@@ -2383,6 +2384,11 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w=="
+    },
     "node_modules/@mapbox/geojson-rewind": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz",
@@ -4672,6 +4678,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/check-error": {

--- a/front/package.json
+++ b/front/package.json
@@ -21,6 +21,7 @@
     "@primeuix/themes": "^1.0.3",
     "@tailwindcss/vite": "^4.0.17",
     "@vue/test-utils": "^2.4.6",
+    "chart.js": "^4.5.0",
     "jsdom": "^26.1.0",
     "maplibre-gl": "^5.4.0",
     "pinia": "^3.0.0",

--- a/front/src/components/contextData/plantability/PlantabilityContextDataList.vue
+++ b/front/src/components/contextData/plantability/PlantabilityContextDataList.vue
@@ -41,16 +41,12 @@ const chartData = computed(() => {
   if (!props.data?.details) return null
 
   let values: number[]
-  try {
-    // Handle case where details is a JSON string containing an array
-    if (typeof props.data.details === "string") {
-      const parsed = JSON.parse(props.data.details)
-      values = Array.isArray(parsed) ? parsed.filter((value) => typeof value === "number") : []
-    } else {
-      // Handle case where details is the expected object structure
-      return null // For now, only handle the array case
-    }
-  } catch {
+  if (typeof props.data.details === "string") {
+    const parsed = JSON.parse(props.data.details)
+    values = Array.isArray(parsed) ? parsed.filter((value) => typeof value === "number") : []
+  } else {
+    // For zoom >= 17 it is props.data.top5LandUse.
+    // Can never happend here but because of type checking need the else
     return null
   }
 
@@ -60,7 +56,6 @@ const chartData = computed(() => {
     frequencyMap.set(value, (frequencyMap.get(value) || 0) + 1)
   })
 
-  // Convert to arrays for chart and map colors correctly
   const scores = Array.from(frequencyMap.keys())
   const labels = scores.map((key) => `Score ${key}`)
   const data = Array.from(frequencyMap.values())
@@ -70,7 +65,7 @@ const chartData = computed(() => {
     const colorIndex = PLANTABILITY_COLOR_MAP.indexOf(score)
     return colorIndex !== -1 && colorIndex + 1 < PLANTABILITY_COLOR_MAP.length
       ? PLANTABILITY_COLOR_MAP[colorIndex + 1]
-      : "#C4C4C4" // fallback gray
+      : "#C4C4C4"
   })
 
   return {
@@ -92,11 +87,16 @@ const chartOptions = computed(() => ({
   plugins: {
     legend: {
       display: true,
-      position: "bottom"
+      position: "bottom",
+      onClick: null // don't allow filtering onClick
     },
     title: {
       display: true,
       text: "Distribution des scores de plantabilité sur la zone."
+    },
+    font: {
+      size: 34,
+      family: "IBM Plex Mono"
     }
   }
 }))

--- a/front/src/components/contextData/plantability/PlantabilityContextDataList.vue
+++ b/front/src/components/contextData/plantability/PlantabilityContextDataList.vue
@@ -57,7 +57,7 @@ const chartData = computed(() => {
   })
 
   const scores = Array.from(frequencyMap.keys())
-  const labels = scores.map((key) => `Score ${key}`)
+  const labels = scores.map((key) => `${key}/10`)
   const data = Array.from(frequencyMap.values())
 
   // Map each score to its corresponding color from PLANTABILITY_COLOR_MAP
@@ -115,6 +115,9 @@ const chartOptions = computed(() => ({
     <template v-else>
       <div v-if="chartData" class="p-4">
         <Chart type="pie" :data="chartData" :options="chartOptions" class="w-full h-64" />
+        <p class="text-sm font-sans text-center m-2">
+          0/10 signifie non plantable et 10/10 plantable
+        </p>
         <empty-message
           data-cy="empty-message"
           message="Zoomez plus pour obtenir l'occupation des sols."

--- a/front/src/composables/useContextData.ts
+++ b/front/src/composables/useContextData.ts
@@ -4,21 +4,37 @@ import type { VulnerabilityData } from "@/types/vulnerability"
 import type { ClimateData } from "@/types/climate"
 import { getTileDetails } from "@/services/tileService"
 import { useMapStore } from "@/stores/map"
+import { DataType } from "@/utils/enum"
 
 export function useContextData() {
   const data = ref<PlantabilityData | VulnerabilityData | ClimateData | null>(null)
   const mapStore = useMapStore()
 
-  const setData = async (featureId: string | number) => {
+  const setData = async (
+    featureId: string | number,
+    indexValue?: string | number,
+    source_values?: any
+  ) => {
     if (!featureId) return null
     const stringId = String(featureId)
-    const tile = await getTileDetails(stringId, mapStore.selectedDataType)
-    if (!tile) {
-      data.value = null
-      return
-    }
+    if (indexValue === undefined) {
+      const tile = await getTileDetails(stringId, mapStore.selectedDataType)
+      data.value = tile
 
-    data.value = tile
+      if (!tile) {
+        data.value = null
+        return
+      }
+    }
+    if (
+      indexValue !== undefined &&
+      source_values !== undefined &&
+      data.value &&
+      data.value.datatype === DataType.PLANTABILITY
+    ) {
+      ;(data.value as PlantabilityData).plantabilityNormalizedIndice = +indexValue
+      ;(data.value as PlantabilityData).details = source_values
+    }
   }
   const removeData = () => {
     data.value = null

--- a/front/src/composables/useContextData.ts
+++ b/front/src/composables/useContextData.ts
@@ -4,7 +4,7 @@ import type { VulnerabilityData } from "@/types/vulnerability"
 import type { ClimateData } from "@/types/climate"
 import { getTileDetails } from "@/services/tileService"
 import { useMapStore } from "@/stores/map"
-import { DataType } from "@/utils/enum"
+import { DataType, DataTypeToGeolevel } from "@/utils/enum"
 
 export function useContextData() {
   const data = ref<PlantabilityData | VulnerabilityData | ClimateData | null>(null)
@@ -29,11 +29,23 @@ export function useContextData() {
     if (
       indexValue !== undefined &&
       source_values !== undefined &&
-      data.value &&
-      data.value.datatype === DataType.PLANTABILITY
+      mapStore.selectedDataType === DataType.PLANTABILITY
     ) {
-      ;(data.value as PlantabilityData).plantabilityNormalizedIndice = +indexValue
-      ;(data.value as PlantabilityData).details = source_values
+      if (!data.value) {
+        data.value = {
+          id: stringId,
+          plantabilityNormalizedIndice: +indexValue,
+          plantabilityIndice: +indexValue,
+          details: source_values,
+          geolevel: DataTypeToGeolevel[mapStore.selectedDataType],
+          datatype: DataType.PLANTABILITY,
+          iris: 0,
+          city: 0
+        } as PlantabilityData
+      } else if (data.value.datatype === DataType.PLANTABILITY) {
+        ;(data.value as PlantabilityData).plantabilityNormalizedIndice = +indexValue
+        ;(data.value as PlantabilityData).details = source_values
+      }
     }
   }
   const removeData = () => {

--- a/front/src/composables/useContextData.ts
+++ b/front/src/composables/useContextData.ts
@@ -18,15 +18,13 @@ export function useContextData() {
     if (!featureId) return null
     const stringId = String(featureId)
     if (indexValue === undefined) {
-      const tile = await getTileDetails(stringId, mapStore.selectedDataType)
-      data.value = tile
+      data.value = await getTileDetails(stringId, mapStore.selectedDataType)
 
-      if (!tile) {
+      if (!data.value) {
         data.value = null
         return
       }
-    }
-    if (
+    } else if (
       indexValue !== undefined &&
       source_values !== undefined &&
       mapStore.selectedDataType === DataType.PLANTABILITY

--- a/front/src/composables/usePlantabilityData.ts
+++ b/front/src/composables/usePlantabilityData.ts
@@ -80,28 +80,12 @@ export function usePlantabilityData(data: Ref<PlantabilityData>) {
     return `Impact ${factorImpact} ${occupationLevel}`
   }
 
-  const filterSensitiveFactors = (landUseData: PlantabilityLandUse | undefined) => {
-    if (!landUseData) return {}
-
-    const factorsToRemove = [
-      PlantabilityLandUseKeys.RSX_SOUTERRAINS_ERDF,
-      PlantabilityLandUseKeys.RSX_AERIENS_ERDF,
-      PlantabilityLandUseKeys.RSX_GAZ,
-      PlantabilityLandUseKeys.ASSAINISSEMENT,
-      PlantabilityLandUseKeys.RESEAU_CHALEUR_URBAIN
-    ]
-
-    return Object.entries(landUseData).reduce((acc, [key, value]) => {
-      if (factorsToRemove.includes(key as PlantabilityLandUseKeys)) {
-        return acc
-      }
-      acc[key as PlantabilityLandUseKeys] = value
-      return acc
-    }, {} as PlantabilityLandUse)
-  }
-
   const factors: ComputedRef<PlantabilityFactor[]> = computed(() => {
-    const landUseData = filterSensitiveFactors(data.value?.details?.top5LandUse)
+    if (typeof data.value?.details === "string") {
+      return [] // No land use factors for histogram data
+    }
+
+    const landUseData = data.value?.details?.top5LandUse
     if (!landUseData) return []
 
     return Object.entries(landUseData).map(([key, value]) => {

--- a/front/src/stores/map.ts
+++ b/front/src/stores/map.ts
@@ -183,14 +183,20 @@ export const useMapStore = defineStore("map", () => {
     }
     const clickHandler = (e: any) => {
       const featureId = extractFeatureProperty(e.features!, datatype, geolevel, "id")
+      const score = extractFeatureProperty(e.features!, datatype, geolevel, "indice")
+      const source_values = extractFeatureProperty(e.features!, datatype, geolevel, "source_values")
       highlightFeature(map, layerId, featureId)
       // Store click coordinates
       clickCoordinates.value = {
         lat: e.lngLat.lat,
         lng: e.lngLat.lng
       }
-      // Always load context data for the selected data type
-      contextData.setData(featureId)
+      // Conditionally load context data based on geolevel, datatype, and zoom
+      if (geolevel === GeoLevel.TILE && datatype === DataType.PLANTABILITY && map.getZoom() < 17) {
+        contextData.setData(featureId, score, source_values)
+      } else {
+        contextData.setData(featureId)
+      }
     }
     map.on("click", layerId, clickHandler)
     mapEventsListener.value[layerId] = clickHandler

--- a/front/src/stores/map.ts
+++ b/front/src/stores/map.ts
@@ -247,6 +247,8 @@ export const useMapStore = defineStore("map", () => {
     selectedDataType.value = datatype
     // Clear filters when changing data type
     clearAllFilters()
+    // Clear context data when changing data type
+    contextData.removeData()
     // Update all map instances with the new layer
     Object.keys(mapInstancesByIds.value).forEach((mapId) => {
       const mapInstance = mapInstancesByIds.value[mapId]

--- a/front/src/types/plantability.ts
+++ b/front/src/types/plantability.ts
@@ -115,7 +115,7 @@ export interface PlantabilityData {
   id: string
   plantabilityNormalizedIndice: number
   plantabilityIndice: number
-  details?: PlantabilityDataDetails
+  details?: PlantabilityDataDetails | string
   geolevel: GeoLevel
   datatype: DataType
   iris: number

--- a/front/src/utils/color.ts
+++ b/front/src/utils/color.ts
@@ -25,8 +25,12 @@ function getElementBackgroundColor(element: HTMLElement): string {
 }
 
 export function getPlantabilityTextColor(percentage: number | null): string {
-  if (!percentage) return "text-gray-300"
-  return percentage >= 80 ? "text-scale-8" : percentage >= 60 ? "text-scale-4" : "text-scale-2"
+  if (!percentage) return "text-gray-300" // Default for null/undefined
+  if (percentage >= 80) return "text-scale-8"
+  if (percentage >= 60) return "text-scale-6"
+  if (percentage >= 40) return "text-scale-4"
+  if (percentage >= 20) return "text-scale-2"
+  return "text-scale-0" //
 }
 
 export function getVulnerabilityTextColor(score: number | null): string {

--- a/front/src/utils/color.ts
+++ b/front/src/utils/color.ts
@@ -25,12 +25,12 @@ function getElementBackgroundColor(element: HTMLElement): string {
 }
 
 export function getPlantabilityTextColor(percentage: number | null): string {
-  if (!percentage) return "text-gray-300" // Default for null/undefined
+  if (percentage === null || percentage === undefined) return "text-gray-300"
   if (percentage >= 80) return "text-scale-8"
   if (percentage >= 60) return "text-scale-6"
   if (percentage >= 40) return "text-scale-4"
   if (percentage >= 20) return "text-scale-2"
-  return "text-scale-0" //
+  return "text-scale-0"
 }
 
 export function getVulnerabilityTextColor(score: number | null): string {


### PR DESCRIPTION
- [x] Ajout d'un pie chart qui représente les scores sur la zone 
- [x] Afficher le badge de score pour des zooms < 17.


Pour rappel pour des zooms >=17 on affiche les tuiles 5mx5m qui contiennent le score calculé et l'occupation des sols. 
Pour des zooms plus petits on affiche des agrégats. Par exemple des tuiles 10mx10m pour le zoom 16 qui contiennent donc 4 tuiles 5mx5m. Le score est alors la moyenne sur les 4 tuiles.

https://feature-plantability-histogr-carte.iarbre.fr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a pie chart to visualize plantability score distribution with legend and caption.

- Improvements
  - Displays all contributing land‑use factors (no filtering).
  - Faster, immediate plantability info on tile click at low zoom.
  - Context panel resets when switching data types.

- Style
  - Refined color scale for better readability of plantability scores.

- Documentation
  - Introduced a comprehensive coding standards guide.

- Chores
  - Added automated review configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->