### PR TITLE
feat: CI triggered by submodule updates

### DIFF
--- a/.github/workflows/showcase.yml
+++ b/.github/workflows/showcase.yml
@@ -9,8 +9,6 @@ on:
       - main
     types:
       - closed
-  # https://stackoverflow.com/questions/72110820/trigger-github-action-in-submodules-from-parent-repo-action
-  # https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event
   repository_dispatch:
     types: [content-updated]
 
@@ -32,4 +30,5 @@ jobs:
           options: |
             -l prod
             ${{ github.event_name == 'repository_dispatch' && '-e force_update=true' || '' }}
+          # if trigerred by dispatch then force_update
           key: ${{ secrets.SSH_PRIVATE_KEY }}


### PR DESCRIPTION
**‼️IL faut regarder aussi la CI du submodule : https://github.com/TelesCoop/iarbre-showcase-content/blob/main/.github/workflows/deploy-showcase.yml‼️**

J'ai utilisé :
      - https://stackoverflow.com/questions/72110820/trigger-github-action-in-submodules-from-parent-repo-action
      - https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event
Le submodule utilise l'API Github pour envoyer un signal au module IArbre de trigger juste showcase.yml.

Ca déclenche donc un build par commit dans les cas de figure où on fait des dizaines de commits en peu de temps, ça peut faire beaucoup de builds.

Après c'est juste des builds hugo et ça arrive très rarement de MAJ tous les articles comme Geoffrey vient de le faire

Le cas d'usage](https://github.com/orgs/TelesCoop/projects/3/views/1?pane=issue&itemId=107578528&issue=TelesCoop%7Ciarbre%7C196) c'est Geoffrey qui à MAJ les articles sur Sveltia mais qui pouvait pas voir sans que je fasse un deploy à la main.
L'autre cas d'usage c'est que écrire un nouvel article demande à chaque fois de deploy à la main (ce que je ne fais jamais) donc il attend le mercredi si y a un push sur main pour être mis en ligne