### PR TITLE
Fix: rendre les QPV plus facilement visible

### DIFF
--- a/front/src/stores/map.ts
+++ b/front/src/stores/map.ts
@@ -30,6 +30,24 @@ import { generateBivariateColorExpression } from "@/utils/plantability_vulnerabi
 import { CLIMATE_ZONE_MAP_COLOR_MAP } from "@/utils/climateZone"
 import { VEGESTRATE_COLOR_MAP, VEGESTRATE_HEIGHT_MAP } from "@/utils/vegetation"
 import { extractFeatureProperty, getLayerId, getSourceId, highlightFeature } from "@/utils/map"
+import {
+  QPV_CASING_COLOR,
+  QPV_CASING_WIDTH,
+  QPV_CASING_OPACITY,
+  QPV_BORDER_COLOR,
+  QPV_BORDER_WIDTH,
+  QPV_BORDER_OPACITY,
+  BOUNDARY_BORDER_COLOR,
+  BOUNDARY_BORDER_WIDTH,
+  BOUNDARY_BORDER_OPACITY,
+  CADASTRE_COLOR,
+  CADASTRE_BORDER_WIDTH,
+  CADASTRE_BORDER_OPACITY,
+  CADASTRE_SELECTED_BORDER_WIDTH,
+  CADASTRE_SELECTED_BORDER_OPACITY,
+  CADASTRE_SELECTED_FILL_OPACITY,
+  CADASTRE_DEFAULT_FILL_OPACITY
+} from "@/utils/mapLayers"
 import { useContextData } from "@/composables/useContextData"
 import { getBivariateCoordinates } from "@/utils/plantability_vulnerability"
 import { addCenterControl, add3DControl } from "@/utils/mapControls"
@@ -498,14 +516,31 @@ export const useMapStore = defineStore("map", () => {
         ? TERRA_DRAW_POLYGON_LAYER
         : undefined
 
+      // White casing drawn first so the coloured line stays legible on any basemap
+      mapInstance.addLayer(
+        {
+          id: "qpv-border-casing",
+          type: "line",
+          source: "qpv-source",
+          paint: {
+            "line-color": QPV_CASING_COLOR,
+            "line-width": QPV_CASING_WIDTH,
+            "line-opacity": QPV_CASING_OPACITY
+          }
+        },
+        beforeId
+      )
+
+      // Main QPV border drawn on top of the casing
       mapInstance.addLayer(
         {
           id: "qpv-border",
           type: "line",
           source: "qpv-source",
           paint: {
-            "line-color": "#D97706",
-            "line-width": 3
+            "line-color": QPV_BORDER_COLOR,
+            "line-width": QPV_BORDER_WIDTH,
+            "line-opacity": QPV_BORDER_OPACITY
           }
         },
         beforeId
@@ -519,6 +554,9 @@ export const useMapStore = defineStore("map", () => {
   const removeQPVLayer = (mapInstance: Map) => {
     if (mapInstance.getLayer("qpv-border")) {
       mapInstance.removeLayer("qpv-border")
+    }
+    if (mapInstance.getLayer("qpv-border-casing")) {
+      mapInstance.removeLayer("qpv-border-casing")
       mapInstance.once("render", () => {
         console.info(`cypress: QPV data removed`)
       })
@@ -564,9 +602,9 @@ export const useMapStore = defineStore("map", () => {
           type: "line",
           source: "city-boundary-source",
           paint: {
-            "line-color": "#426A45",
-            "line-width": 2.5,
-            "line-opacity": 0.7
+            "line-color": BOUNDARY_BORDER_COLOR,
+            "line-width": BOUNDARY_BORDER_WIDTH,
+            "line-opacity": BOUNDARY_BORDER_OPACITY
           }
         },
         beforeId
@@ -626,7 +664,7 @@ export const useMapStore = defineStore("map", () => {
           source: "cadastre-source",
           "source-layer": "cadastre--cadastre",
           paint: {
-            "fill-color": "#8B6914",
+            "fill-color": CADASTRE_COLOR,
             "fill-opacity": 0.0
           }
         },
@@ -642,9 +680,9 @@ export const useMapStore = defineStore("map", () => {
           source: "cadastre-source",
           "source-layer": "cadastre--cadastre",
           paint: {
-            "line-color": "#8B6914",
-            "line-width": 1,
-            "line-opacity": 0.5
+            "line-color": CADASTRE_COLOR,
+            "line-width": CADASTRE_BORDER_WIDTH,
+            "line-opacity": CADASTRE_BORDER_OPACITY
           }
         },
         beforeId
@@ -668,22 +706,22 @@ export const useMapStore = defineStore("map", () => {
         "match",
         ["get", "parcel_id"],
         parcelId,
-        0.3,
-        0.05
+        CADASTRE_SELECTED_FILL_OPACITY,
+        CADASTRE_DEFAULT_FILL_OPACITY
       ])
       mapInstance.setPaintProperty("cadastre-border", "line-width", [
         "match",
         ["get", "parcel_id"],
         parcelId,
-        3,
-        1
+        CADASTRE_SELECTED_BORDER_WIDTH,
+        CADASTRE_BORDER_WIDTH
       ])
       mapInstance.setPaintProperty("cadastre-border", "line-opacity", [
         "match",
         ["get", "parcel_id"],
         parcelId,
-        1,
-        0.5
+        CADASTRE_SELECTED_BORDER_OPACITY,
+        CADASTRE_BORDER_OPACITY
       ])
     }
 
@@ -714,9 +752,9 @@ export const useMapStore = defineStore("map", () => {
     for (const mapId of Object.keys(mapInstancesByIds.value)) {
       const mapInstance = mapInstancesByIds.value[mapId]
       if (!mapInstance.getLayer("cadastre-fill")) continue
-      mapInstance.setPaintProperty("cadastre-fill", "fill-opacity", 0.05)
-      mapInstance.setPaintProperty("cadastre-border", "line-width", 1)
-      mapInstance.setPaintProperty("cadastre-border", "line-opacity", 0.5)
+      mapInstance.setPaintProperty("cadastre-fill", "fill-opacity", CADASTRE_DEFAULT_FILL_OPACITY)
+      mapInstance.setPaintProperty("cadastre-border", "line-width", CADASTRE_BORDER_WIDTH)
+      mapInstance.setPaintProperty("cadastre-border", "line-opacity", CADASTRE_BORDER_OPACITY)
     }
   }
 

--- a/front/src/stores/map.ts
+++ b/front/src/stores/map.ts
@@ -37,16 +37,19 @@ import {
   QPV_BORDER_COLOR,
   QPV_BORDER_WIDTH,
   QPV_BORDER_OPACITY,
-  BOUNDARY_BORDER_COLOR,
-  BOUNDARY_BORDER_WIDTH,
-  BOUNDARY_BORDER_OPACITY,
+  CITY_BORDER_COLOR,
+  CITY_BORDER_WIDTH,
+  CITY_BORDER_OPACITY,
   CADASTRE_COLOR,
   CADASTRE_BORDER_WIDTH,
   CADASTRE_BORDER_OPACITY,
   CADASTRE_SELECTED_BORDER_WIDTH,
   CADASTRE_SELECTED_BORDER_OPACITY,
   CADASTRE_SELECTED_FILL_OPACITY,
-  CADASTRE_DEFAULT_FILL_OPACITY
+  CADASTRE_DEFAULT_FILL_OPACITY,
+  CITY_CASING_COLOR,
+  CITY_CASING_WIDTH,
+  CITY_CASING_OPACITY
 } from "@/utils/mapLayers"
 import { useContextData } from "@/composables/useContextData"
 import { getBivariateCoordinates } from "@/utils/plantability_vulnerability"
@@ -596,15 +599,29 @@ export const useMapStore = defineStore("map", () => {
       : undefined
 
     if (!mapInstance.getLayer("city-boundary")) {
+      // White casing drawn first so the coloured line stays legible on any basemap
+      mapInstance.addLayer(
+        {
+          id: "city-boundary-border-casing",
+          type: "line",
+          source: "city-boundary-source",
+          paint: {
+            "line-color": CITY_CASING_COLOR,
+            "line-width": CITY_CASING_WIDTH,
+            "line-opacity": CITY_CASING_OPACITY
+          }
+        },
+        beforeId
+      )
       mapInstance.addLayer(
         {
           id: "city-boundary",
           type: "line",
           source: "city-boundary-source",
           paint: {
-            "line-color": BOUNDARY_BORDER_COLOR,
-            "line-width": BOUNDARY_BORDER_WIDTH,
-            "line-opacity": BOUNDARY_BORDER_OPACITY
+            "line-color": CITY_BORDER_COLOR,
+            "line-width": CITY_BORDER_WIDTH,
+            "line-opacity": CITY_BORDER_OPACITY
           }
         },
         beforeId

--- a/front/src/utils/mapLayers.ts
+++ b/front/src/utils/mapLayers.ts
@@ -1,0 +1,39 @@
+/**
+ * Style constants for overlay map layers (QPV, communes boundaries, cadastre).
+ * These constants centralise colors and widths so that visual changes
+ * only need to be made in one place.
+ */
+
+// ---------------------------------------------------------------------------
+// QPV (Quartiers Prioritaires de la Ville)
+// ---------------------------------------------------------------------------
+
+/** White halo drawn behind the QPV line so it stays legible on every basemap. */
+export const QPV_CASING_COLOR = "#FFFFFF"
+export const QPV_CASING_WIDTH = 3
+export const QPV_CASING_OPACITY = 0.9
+
+/** Main QPV border colour – vivid violet, visible on light, dark and satellite backgrounds. */
+export const QPV_BORDER_COLOR = "#7C3AED"
+export const QPV_BORDER_WIDTH = 1
+export const QPV_BORDER_OPACITY = 1
+
+// ---------------------------------------------------------------------------
+// Communes (city boundaries)
+// ---------------------------------------------------------------------------
+
+export const BOUNDARY_BORDER_COLOR = "#426A45"
+export const BOUNDARY_BORDER_WIDTH = 2.5
+export const BOUNDARY_BORDER_OPACITY = 0.7
+
+// ---------------------------------------------------------------------------
+// Cadastre
+// ---------------------------------------------------------------------------
+
+export const CADASTRE_COLOR = "#8B6914"
+export const CADASTRE_BORDER_WIDTH = 1
+export const CADASTRE_BORDER_OPACITY = 0.5
+export const CADASTRE_SELECTED_BORDER_WIDTH = 3
+export const CADASTRE_SELECTED_BORDER_OPACITY = 1
+export const CADASTRE_SELECTED_FILL_OPACITY = 0.3
+export const CADASTRE_DEFAULT_FILL_OPACITY = 0.05

--- a/front/src/utils/mapLayers.ts
+++ b/front/src/utils/mapLayers.ts
@@ -4,25 +4,29 @@
  * only need to be made in one place.
  */
 
+function getCssVar(name: string): string {
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim()
+}
+
 // ---------------------------------------------------------------------------
 // QPV (Quartiers Prioritaires de la Ville)
 // ---------------------------------------------------------------------------
 
 /** White halo drawn behind the QPV line so it stays legible on every basemap. */
 export const QPV_CASING_COLOR = "#FFFFFF"
-export const QPV_CASING_WIDTH = 3
+export const QPV_CASING_WIDTH = 6
 export const QPV_CASING_OPACITY = 0.9
 
-/** Main QPV border colour – vivid violet, visible on light, dark and satellite backgrounds. */
-export const QPV_BORDER_COLOR = "#7C3AED"
-export const QPV_BORDER_WIDTH = 1
+/** Main QPV border colour. */
+export const QPV_BORDER_COLOR = getCssVar("--color-primary-900")
+export const QPV_BORDER_WIDTH = 2.5
 export const QPV_BORDER_OPACITY = 1
 
 // ---------------------------------------------------------------------------
 // Communes (city boundaries)
 // ---------------------------------------------------------------------------
 
-export const BOUNDARY_BORDER_COLOR = "#426A45"
+export const BOUNDARY_BORDER_COLOR = getCssVar("--color-primary-500")
 export const BOUNDARY_BORDER_WIDTH = 2.5
 export const BOUNDARY_BORDER_OPACITY = 0.7
 

--- a/front/src/utils/mapLayers.ts
+++ b/front/src/utils/mapLayers.ts
@@ -25,10 +25,13 @@ export const QPV_BORDER_OPACITY = 1
 // ---------------------------------------------------------------------------
 // Communes (city boundaries)
 // ---------------------------------------------------------------------------
+export const CITY_CASING_COLOR = "#FFFFFF"
+export const CITY_CASING_WIDTH = 6
+export const CITY_CASING_OPACITY = 0.9
 
-export const BOUNDARY_BORDER_COLOR = getCssVar("--color-primary-500")
-export const BOUNDARY_BORDER_WIDTH = 2.5
-export const BOUNDARY_BORDER_OPACITY = 0.7
+export const CITY_BORDER_COLOR = getCssVar("--color-primary-500")
+export const CITY_BORDER_WIDTH = 2.5
+export const CITY_BORDER_OPACITY = 0.7
 
 // ---------------------------------------------------------------------------
 // Cadastre


### PR DESCRIPTION
https://github.com/TelesCoop/iarbre/issues/618 

# Réalisé
- Création d'un fichier où on voit directement l'ensemble des styles pour le cadastre, les QPV et le contour des communes
- Je sais pas si la couleur violette est ok par rapport à l'ensemble des couleurs