### PR TITLE
enh: add a dedicated gunicorn supervisor for WFS/WMS

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,5 +1,9 @@
 # Deploy IArbre
 
+## Gunicorn supervisors
+
+Il y a 2 gunicorn qui tournent, le classique et un deuxième `-gisserver` qui ne s'occupe que des requêtes sur `api/wfs/` et `api/wms`. L'objectif est de ne pas saturer les workers de la carto avec ces requêtes.
+
 ## Premier déploiement certbot
 
 ```

--- a/deploy/group_vars/all/vars.yml
+++ b/deploy/group_vars/all/vars.yml
@@ -19,6 +19,8 @@ database_user: "{{ project_slug }}"
 database_name: "{{ project_slug }}"
 
 requests_timeout: 120
+wfs_workers: 8
+wfs_requests_timeout: 300
 # if using postgresql database, you will need to
 # - define the var `database_password`
 # - install an additional Ansible module `ansible-galaxy collection install community.postgresql`

--- a/deploy/group_vars/all/vars.yml
+++ b/deploy/group_vars/all/vars.yml
@@ -19,8 +19,8 @@ database_user: "{{ project_slug }}"
 database_name: "{{ project_slug }}"
 
 requests_timeout: 120
-wfs_workers: 8
-wfs_requests_timeout: 300
+gisserver_workers: 8
+gisserver_requests_timeout: 300
 # if using postgresql database, you will need to
 # - define the var `database_password`
 # - install an additional Ansible module `ansible-galaxy collection install community.postgresql`

--- a/deploy/group_vars/feature/vars.yml
+++ b/deploy/group_vars/feature/vars.yml
@@ -3,6 +3,7 @@ branch_hash: "{{ branch_slug | hash('md5') }}"
 unique_number: "{{ (branch_hash | int(0, 16) % 900) + 100 }}"
 
 backend_application_port: "8{{ unique_number }}" # deterministic port based on branch name
+wfs_application_port: "9{{ unique_number }}"
 frontend_application_port: "3{{ unique_number }}" # deterministic port based on branch name
 environment_suffix: "-feature-{{ branch_slug }}"
 project_slug: "{{ base_project_slug }}{{ environment_suffix }}"

--- a/deploy/group_vars/feature/vars.yml
+++ b/deploy/group_vars/feature/vars.yml
@@ -3,7 +3,7 @@ branch_hash: "{{ branch_slug | hash('md5') }}"
 unique_number: "{{ (branch_hash | int(0, 16) % 900) + 100 }}"
 
 backend_application_port: "8{{ unique_number }}" # deterministic port based on branch name
-wfs_application_port: "9{{ unique_number }}"
+gisserver_application_port: "9{{ unique_number }}"
 frontend_application_port: "3{{ unique_number }}" # deterministic port based on branch name
 environment_suffix: "-feature-{{ branch_slug }}"
 project_slug: "{{ base_project_slug }}{{ environment_suffix }}"

--- a/deploy/group_vars/preprod/vars.yml
+++ b/deploy/group_vars/preprod/vars.yml
@@ -1,4 +1,5 @@
 backend_application_port: 8032 # must be unique for each project on the same server
+wfs_application_port: 8034
 frontend_application_port: 3002 # must be unique for each project on the same server
 environment_suffix: "_preprod"
 project_slug: "{{ base_project_slug }}{{ environment_suffix }}"

--- a/deploy/group_vars/preprod/vars.yml
+++ b/deploy/group_vars/preprod/vars.yml
@@ -1,5 +1,5 @@
 backend_application_port: 8032 # must be unique for each project on the same server
-wfs_application_port: 8034
+gisserver_application_port: 8034
 frontend_application_port: 3002 # must be unique for each project on the same server
 environment_suffix: "_preprod"
 project_slug: "{{ base_project_slug }}{{ environment_suffix }}"

--- a/deploy/group_vars/prod/vars.yml
+++ b/deploy/group_vars/prod/vars.yml
@@ -1,4 +1,5 @@
 backend_application_port: 8031 # must be unique for each project on the same server
+wfs_application_port: 8033
 frontend_application_port: 3000 # must be unique for each project on the same server
 environment_suffix: ""
 project_slug: "{{ base_project_slug }}{{ environment_suffix }}"

--- a/deploy/group_vars/prod/vars.yml
+++ b/deploy/group_vars/prod/vars.yml
@@ -1,5 +1,5 @@
 backend_application_port: 8031 # must be unique for each project on the same server
-wfs_application_port: 8033
+gisserver_application_port: 8033
 frontend_application_port: 3000 # must be unique for each project on the same server
 environment_suffix: ""
 project_slug: "{{ base_project_slug }}{{ environment_suffix }}"

--- a/deploy/telescoop-deploy/tasks/clean-django.yml
+++ b/deploy/telescoop-deploy/tasks/clean-django.yml
@@ -14,6 +14,22 @@
     name: "{{ project_slug }}-backend"
     state: absent
 
+- name: Remove WFS supervisor configuration
+  file:
+    path: "{{ supervisor_conf }}/{{ project_slug }}_backend_wfs.conf"
+    state: absent
+
+- name: Stop WFS supervisor process
+  supervisorctl:
+    name: "{{ project_slug }}-backend-wfs"
+    state: stopped
+  ignore_errors: yes
+
+- name: Remove WFS supervisor process
+  supervisorctl:
+    name: "{{ project_slug }}-backend-wfs"
+    state: absent
+
 - name: Remove control script
   file:
     path: "/usr/local/bin/{{ project_slug }}-ctl"

--- a/deploy/telescoop-deploy/tasks/clean-django.yml
+++ b/deploy/telescoop-deploy/tasks/clean-django.yml
@@ -14,20 +14,20 @@
     name: "{{ project_slug }}-backend"
     state: absent
 
-- name: Remove WFS supervisor configuration
+- name: Remove GIS server supervisor configuration
   file:
     path: "{{ supervisor_conf }}/{{ project_slug }}_backend_wfs.conf"
     state: absent
 
-- name: Stop WFS supervisor process
+- name: Stop GIS server supervisor process
   supervisorctl:
-    name: "{{ project_slug }}-backend-wfs"
+    name: "{{ project_slug }}-backend-gisserver"
     state: stopped
   ignore_errors: yes
 
-- name: Remove WFS supervisor process
+- name: Remove GIS server supervisor process
   supervisorctl:
-    name: "{{ project_slug }}-backend-wfs"
+    name: "{{ project_slug }}-backend-gisserver"
     state: absent
 
 - name: Remove control script

--- a/deploy/telescoop-deploy/tasks/clean-django.yml
+++ b/deploy/telescoop-deploy/tasks/clean-django.yml
@@ -16,7 +16,7 @@
 
 - name: Remove GIS server supervisor configuration
   file:
-    path: "{{ supervisor_conf }}/{{ project_slug }}_backend_wfs.conf"
+    path: "{{ supervisor_conf }}/{{ project_slug }}_backend_gisserver.conf"
     state: absent
 
 - name: Stop GIS server supervisor process

--- a/deploy/telescoop-deploy/tasks/install-and-update-django.yml
+++ b/deploy/telescoop-deploy/tasks/install-and-update-django.yml
@@ -30,17 +30,17 @@
     name: "{{ project_slug }}-backend"
     state: present
 
-- name: Copy supervisord WFS config to {{ supervisor_conf }}/{{ project_slug }}_backend_wfs.conf
+- name: Copy supervisord GIS server config to {{ supervisor_conf }}/{{ project_slug }}_backend_gisserver.conf
   template:
-    src: django-supervisor-wfs.conf.j2
-    dest: "{{ supervisor_conf }}/{{ project_slug }}_backend_wfs.conf"
+    src: django-supervisor-gisserver.conf.j2
+    dest: "{{ supervisor_conf }}/{{ project_slug }}_backend_gisserver.conf"
     owner: root
     group: root
     mode: 0644
 
-- name: Install {{ project_slug }}-backend-wfs supervisor
+- name: Install {{ project_slug }}-backend-gisserver supervisor
   supervisorctl:
-    name: "{{ project_slug }}-backend-wfs"
+    name: "{{ project_slug }}-backend-gisserver"
     state: present
 
 - name: Run migrations with conflict handling
@@ -72,9 +72,9 @@
     state: restarted
   when: clonecode.changed or force_update is defined
 
-- name: Restart {{ project_slug }}-backend-wfs supervisor
+- name: Restart {{ project_slug }}-backend-gisserver supervisor
   supervisorctl:
-    name: "{{ project_slug }}-backend-wfs"
+    name: "{{ project_slug }}-backend-gisserver"
     state: restarted
   when: clonecode.changed or force_update is defined
 # - name: "daily database backup"

--- a/deploy/telescoop-deploy/tasks/install-and-update-django.yml
+++ b/deploy/telescoop-deploy/tasks/install-and-update-django.yml
@@ -30,6 +30,19 @@
     name: "{{ project_slug }}-backend"
     state: present
 
+- name: Copy supervisord WFS config to {{ supervisor_conf }}/{{ project_slug }}_backend_wfs.conf
+  template:
+    src: django-supervisor-wfs.conf.j2
+    dest: "{{ supervisor_conf }}/{{ project_slug }}_backend_wfs.conf"
+    owner: root
+    group: root
+    mode: 0644
+
+- name: Install {{ project_slug }}-backend-wfs supervisor
+  supervisorctl:
+    name: "{{ project_slug }}-backend-wfs"
+    state: present
+
 - name: Run migrations with conflict handling
   shell: |
     {{ project_slug }}-ctl migrate || {
@@ -56,6 +69,12 @@
 - name: Restart {{ project_slug }} supervisor
   supervisorctl:
     name: "{{ project_slug }}-backend"
+    state: restarted
+  when: clonecode.changed or force_update is defined
+
+- name: Restart {{ project_slug }}-backend-wfs supervisor
+  supervisorctl:
+    name: "{{ project_slug }}-backend-wfs"
     state: restarted
   when: clonecode.changed or force_update is defined
 # - name: "daily database backup"

--- a/deploy/telescoop-deploy/tasks/install-and-update-django.yml
+++ b/deploy/telescoop-deploy/tasks/install-and-update-django.yml
@@ -38,6 +38,12 @@
     group: root
     mode: 0644
 
+- name: Reload supervisord config
+  command: supervisorctl reread
+
+- name: Update supervisord processes
+  command: supervisorctl update
+
 - name: Install {{ project_slug }}-backend-gisserver supervisor
   supervisorctl:
     name: "{{ project_slug }}-backend-gisserver"
@@ -77,6 +83,20 @@
     name: "{{ project_slug }}-backend-gisserver"
     state: restarted
   when: clonecode.changed or force_update is defined
+
+- name: Verify backend is running
+  uri:
+    url: "http://localhost:{{ backend_application_port }}/api/health-check/"
+    status_code: 200
+  retries: 5
+  delay: 3
+
+- name: Verify gisserver is running
+  uri:
+    url: "http://localhost:{{ gisserver_application_port }}/api/health-check/"
+    status_code: 200
+  retries: 5
+  delay: 3
 # - name: "daily database backup"
 #   cron:
 #     user: "{{ main_user }}"

--- a/deploy/telescoop-deploy/tasks/templates/django-supervisor-gisserver.conf.j2
+++ b/deploy/telescoop-deploy/tasks/templates/django-supervisor-gisserver.conf.j2
@@ -1,0 +1,7 @@
+[program:{{ project_slug }}-backend-wfs]
+directory = {{ django_path }} ;
+command = {{ venv.path }}/bin/gunicorn {{ django_project_name }}.wsgi --name "{{ project_slug }}-wfs" --timeout {{ gisserver_requests_timeout }} --workers={{ gisserver_workers }} --bind=localhost:{{ gisserver_application_port }} --user="{{ main_user }}"
+user = {{ main_user }} ; User to run as
+stdout_logfile = {{ var_log_path }}/gunicorn_supervisor_gisserver.log        ; Where to write log messages
+redirect_stderr = true                                                ; Save stderr in the same log
+environment=LANG="en_US.UTF-8",LC_ALL="en_US.UTF-8",PYTHONIOENCODING="utf8",CONFIG_PATH="{{ django_settings_path }}"

--- a/deploy/telescoop-deploy/tasks/templates/django-supervisor-gisserver.conf.j2
+++ b/deploy/telescoop-deploy/tasks/templates/django-supervisor-gisserver.conf.j2
@@ -1,6 +1,6 @@
-[program:{{ project_slug }}-backend-wfs]
+[program:{{ project_slug }}-backend-gisserver]
 directory = {{ django_path }} ;
-command = {{ venv.path }}/bin/gunicorn {{ django_project_name }}.wsgi --name "{{ project_slug }}-wfs" --timeout {{ gisserver_requests_timeout }} --workers={{ gisserver_workers }} --bind=localhost:{{ gisserver_application_port }} --user="{{ main_user }}"
+command = {{ venv.path }}/bin/gunicorn {{ django_project_name }}.wsgi --name "{{ project_slug }}-gisserver" --timeout {{ gisserver_requests_timeout }} --workers={{ gisserver_workers }} --bind=localhost:{{ gisserver_application_port }} --user="{{ main_user }}"
 user = {{ main_user }} ; User to run as
 stdout_logfile = {{ var_log_path }}/gunicorn_supervisor_gisserver.log        ; Where to write log messages
 redirect_stderr = true                                                ; Save stderr in the same log

--- a/deploy/telescoop-deploy/tasks/templates/django-supervisor-wfs.conf.j2
+++ b/deploy/telescoop-deploy/tasks/templates/django-supervisor-wfs.conf.j2
@@ -1,7 +1,0 @@
-[program:{{ project_slug }}-backend-wfs]
-directory = {{ django_path }} ;
-command = {{ venv.path }}/bin/gunicorn {{ django_project_name }}.wsgi --name "{{ project_slug }}-wfs" --timeout {{ wfs_requests_timeout }} --workers={{ wfs_workers }} --bind=localhost:{{ wfs_application_port }} --user="{{ main_user }}"
-user = {{ main_user }} ; User to run as
-stdout_logfile = {{ var_log_path }}/gunicorn_supervisor_wfs.log        ; Where to write log messages
-redirect_stderr = true                                                ; Save stderr in the same log
-environment=LANG="en_US.UTF-8",LC_ALL="en_US.UTF-8",PYTHONIOENCODING="utf8",CONFIG_PATH="{{ django_settings_path }}"

--- a/deploy/telescoop-deploy/tasks/templates/django-supervisor-wfs.conf.j2
+++ b/deploy/telescoop-deploy/tasks/templates/django-supervisor-wfs.conf.j2
@@ -1,0 +1,7 @@
+[program:{{ project_slug }}-backend-wfs]
+directory = {{ django_path }} ;
+command = {{ venv.path }}/bin/gunicorn {{ django_project_name }}.wsgi --name "{{ project_slug }}-wfs" --timeout {{ wfs_requests_timeout }} --workers={{ wfs_workers }} --bind=localhost:{{ wfs_application_port }} --user="{{ main_user }}"
+user = {{ main_user }} ; User to run as
+stdout_logfile = {{ var_log_path }}/gunicorn_supervisor_wfs.log        ; Where to write log messages
+redirect_stderr = true                                                ; Save stderr in the same log
+environment=LANG="en_US.UTF-8",LC_ALL="en_US.UTF-8",PYTHONIOENCODING="utf8",CONFIG_PATH="{{ django_settings_path }}"

--- a/deploy/telescoop-deploy/tasks/templates/nginx.conf.j2
+++ b/deploy/telescoop-deploy/tasks/templates/nginx.conf.j2
@@ -4,6 +4,10 @@
 upstream app_servers_{{ project_slug }} {
   server 127.0.0.1:{{ backend_application_port }};
 }
+
+upstream app_servers_wfs_{{ project_slug }} {
+  server 127.0.0.1:{{ wfs_application_port }};
+}
 {% endif %}
 
 {% if frontend_mode == "SSR" -%}
@@ -87,7 +91,7 @@ server {
     }
 
     location /api/wfs/ {
-        proxy_pass         http://app_servers_{{ project_slug }};
+        proxy_pass         http://app_servers_wfs_{{ project_slug }};
         proxy_redirect     off;
         proxy_set_header   Host $host;
         proxy_set_header   X-Real-IP $remote_addr;
@@ -100,6 +104,16 @@ server {
         proxy_cache_key    "$uri$is_args$args";
         proxy_cache_lock   on;
         add_header         X-Cache-Status $upstream_cache_status;
+    }
+
+    location /api/wms/ {
+        proxy_pass         http://app_servers_wfs_{{ project_slug }};
+        proxy_redirect     off;
+        proxy_set_header   Host $host;
+        proxy_set_header   X-Real-IP $remote_addr;
+        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Host $server_name;
+        proxy_set_header   X-Forwarded-Proto $scheme;
     }
 
     location ~ ^/api/(tiles|dashboard|boundaries|rasters|cities|iris|metadata)/ {

--- a/deploy/telescoop-deploy/tasks/templates/nginx.conf.j2
+++ b/deploy/telescoop-deploy/tasks/templates/nginx.conf.j2
@@ -5,8 +5,8 @@ upstream app_servers_{{ project_slug }} {
   server 127.0.0.1:{{ backend_application_port }};
 }
 
-upstream app_servers_wfs_{{ project_slug }} {
-  server 127.0.0.1:{{ wfs_application_port }};
+upstream app_servers_gisserver_{{ project_slug }} {
+  server 127.0.0.1:{{ gisserver_application_port }};
 }
 {% endif %}
 
@@ -91,7 +91,7 @@ server {
     }
 
     location /api/wfs/ {
-        proxy_pass         http://app_servers_wfs_{{ project_slug }};
+        proxy_pass         http://app_servers_gisserver_{{ project_slug }};
         proxy_redirect     off;
         proxy_set_header   Host $host;
         proxy_set_header   X-Real-IP $remote_addr;
@@ -107,7 +107,7 @@ server {
     }
 
     location /api/wms/ {
-        proxy_pass         http://app_servers_wfs_{{ project_slug }};
+        proxy_pass         http://app_servers_gisserver_{{ project_slug }};
         proxy_redirect     off;
         proxy_set_header   Host $host;
         proxy_set_header   X-Real-IP $remote_addr;


### PR DESCRIPTION
Modifs des fichiers de deploy par Claude pour copier la conf de gunicorn supervisor et re-direct les demandes sur `api/wfs/` et `api/wms` vers ces workers dédiés qui ne font que ça. 

Plus de raisons que ces DLs bloquent la carto et autres. 

Ca aurait pu être de faire de l'async vu qu'en particulier WFS est très I/O mais ça me semblait plus compliqué et je n'aurais pas maitrisé alors que là j"ai pu relire