### PR TITLE
🔖 0.31.0 (2026-05-27) : Tableau de bord narratif et améliorations des services WMF/WMS

### DIFF
--- a/deploy/backend.yml
+++ b/deploy/backend.yml
@@ -90,4 +90,8 @@
             }
           become: true
 
+        - name: Remove test fixtures (Villard-de-Lans) from restored database
+          shell:
+            cmd: "{{ project_slug }}-ctl delete_test_data"
+
       when: dedicated_database and (clonecode.changed or force_update is defined)

--- a/docs/changelog/product.md
+++ b/docs/changelog/product.md
@@ -6,7 +6,7 @@
 
 Le tableau de bord permet de résumer les indicateurs de la cartographie et de les croiser sur un territoire sélectionné. C'était précédement une collection en grille, ce qui rendait difficile l'inteprétation. Nous avons re-travaillé les graphiques et essayé de rendre ce tableau de bord plus narratif afin de mieux comprendre rapidement les grands enjeux avant de se plonger dans la cartographie.
 
-$rarr; PR[#651](https://github.com/TelesCoop/iarbre/pull/651)
+&rarr; PR[#651](https://github.com/TelesCoop/iarbre/pull/651)
 
 ### 🛠️ enhance : Sortir le site vitrine du mono repo
 
@@ -14,24 +14,24 @@ Le site vitrine alourdissait le mono-repo avec la synchronisation de son contenu
 Il a maintenant son [repo](https://github.com/TelesCoop/iarbre-website) dédié. Il y a une légère refonte au passage pour clarifier la proposition
 de valeur.
 
-$rarr; PR[#629](https://github.com/TelesCoop/iarbre/pull/629)
+&rarr; PR[#629](https://github.com/TelesCoop/iarbre/pull/629)
 
 ### ✨ feat : Ajout d'un service WMS
 
 Un endpoint permet maintenant de se connecter à un flux WMS, depuis QGIS par exemple. Les explications pour se connecter sont dispo en bas à gauche
 de la cartographie `Obtenir les données`. L'API REST pour récupérer les rasters (GeoTIFF) en entier a aussi été complété. On peut maintenant récupérer tous les calques colorisées ou en version "brute" c'est à dire en niveau de gris avec les classes.
 
-$rarr; PR[#613](https://github.com/TelesCoop/iarbre/pull/613)
+&rarr; PR[#613](https://github.com/TelesCoop/iarbre/pull/613)
 
 ### 🛠️ enhance : Ajout d'un supervisor dédié pour les flux
 
 Des process se chargent uniquement de partager les flux WFS/WMS et ne peuvent donc plus bloquer la navigation sur la cartographie.
 
-$rarr; PR[#656](https://github.com/TelesCoop/iarbre/pull/656)
+&rarr; PR[#656](https://github.com/TelesCoop/iarbre/pull/656)
 
 ### 🛠️ enhance : Améliorations UI/UX sur les boutons de cadastres, QPV et communes
 
-$rarr; PR[#646](https://github.com/TelesCoop/iarbre/pull/646)
+&rarr; PR[#646](https://github.com/TelesCoop/iarbre/pull/646)
 
 ## 🔖 0.30.0 (2026-05-06) : Interactivité du calque de biodiversité
 
@@ -39,7 +39,7 @@ $rarr; PR[#646](https://github.com/TelesCoop/iarbre/pull/646)
 
 La palette de couleur a été retravaillé ainsi que la légende mais surtout maintenant on peut cliquer sur le calque pour obtenir l'occupation des sols dans un rayon de 1kms et donc une explicabilité du score.
 
-$rarr; PR[#636](https://github.com/TelesCoop/iarbre/pull/636)
+&rarr; PR[#636](https://github.com/TelesCoop/iarbre/pull/636)
 
 ## 🔖 0.29.0 (2026-04-29) : Ajout de documentation métier et améliorations de l'UX
 

--- a/docs/changelog/product.md
+++ b/docs/changelog/product.md
@@ -1,5 +1,38 @@
 # Journal des changements
 
+## 🔖 0.31.0 (2026-05-27) : Tableau de bord narratif et améliorations des services WMF/WMS
+
+### ✨ feat : Tableau de bord narratif
+
+Le tableau de bord permet de résumer les indicateurs de la cartographie et de les croiser sur un territoire sélectionné. C'était précédement une collection en grille, ce qui rendait difficile l'inteprétation. Nous avons re-travaillé les graphiques et essayé de rendre ce tableau de bord plus narratif afin de mieux comprendre rapidement les grands enjeux avant de se plonger dans la cartographie.
+
+$rarr; PR[#651](https://github.com/TelesCoop/iarbre/pull/651)
+
+### 🛠️ enhance : Sortir le site vitrine du mono repo
+
+Le site vitrine alourdissait le mono-repo avec la synchronisation de son contenu. De plus il fallait une mise en production pour le mettre à jour.
+Il a maintenant son [repo](https://github.com/TelesCoop/iarbre-website) dédié. Il y a une légère refonte au passage pour clarifier la proposition
+de valeur.
+
+$rarr; PR[#629](https://github.com/TelesCoop/iarbre/pull/629)
+
+### ✨ feat : Ajout d'un service WMS
+
+Un endpoint permet maintenant de se connecter à un flux WMS, depuis QGIS par exemple. Les explications pour se connecter sont dispo en bas à gauche
+de la cartographie `Obtenir les données`. L'API REST pour récupérer les rasters (GeoTIFF) en entier a aussi été complété. On peut maintenant récupérer tous les calques colorisées ou en version "brute" c'est à dire en niveau de gris avec les classes.
+
+$rarr; PR[#613](https://github.com/TelesCoop/iarbre/pull/613)
+
+### 🛠️ enhance : Ajout d'un supervisor dédié pour les flux
+
+Des process se chargent uniquement de partager les flux WFS/WMS et ne peuvent donc plus bloquer la navigation sur la cartographie.
+
+$rarr; PR[#656](https://github.com/TelesCoop/iarbre/pull/656)
+
+### 🛠️ enhance : Améliorations UI/UX sur les boutons de cadastres, QPV et communes
+
+$rarr; PR[#646](https://github.com/TelesCoop/iarbre/pull/646)
+
 ## 🔖 0.30.0 (2026-05-06) : Interactivité du calque de biodiversité
 
 ### ✨ feat : Obtenir des détails du score de biodiversité


### PR DESCRIPTION
### ✨ feat : Tableau de bord narratif

Le tableau de bord permet de résumer les indicateurs de la cartographie et de les croiser sur un territoire sélectionné. C'était précédement une collection en grille, ce qui rendait difficile l'inteprétation. Nous avons re-travaillé les graphiques et essayé de rendre ce tableau de bord plus narratif afin de mieux comprendre rapidement les grands enjeux avant de se plonger dans la cartographie.

&rarr; PR[#651](https://github.com/TelesCoop/iarbre/pull/651)

### 🛠️ enhance : Sortir le site vitrine du mono repo

Le site vitrine alourdissait le mono-repo avec la synchronisation de son contenu. De plus il fallait une mise en production pour le mettre à jour.
Il a maintenant son [repo](https://github.com/TelesCoop/iarbre-website) dédié. Il y a une légère refonte au passage pour clarifier la proposition
de valeur.

&rarr; PR[#629](https://github.com/TelesCoop/iarbre/pull/629)

### ✨ feat : Ajout d'un service WMS

Un endpoint permet maintenant de se connecter à un flux WMS, depuis QGIS par exemple. Les explications pour se connecter sont dispo en bas à gauche
de la cartographie `Obtenir les données`. L'API REST pour récupérer les rasters (GeoTIFF) en entier a aussi été complété. On peut maintenant récupérer tous les calques colorisées ou en version "brute" c'est à dire en niveau de gris avec les classes.

&rarr; PR[#613](https://github.com/TelesCoop/iarbre/pull/613)

### 🛠️ enhance : Ajout d'un supervisor dédié pour les flux

Des process se chargent uniquement de partager les flux WFS/WMS et ne peuvent donc plus bloquer la navigation sur la cartographie.

&rarr; PR[#656](https://github.com/TelesCoop/iarbre/pull/656)

### 🛠️ enhance : Améliorations UI/UX sur les boutons de cadastres, QPV et communes

&rarr; PR[#646](https://github.com/TelesCoop/iarbre/pull/646)