### PR TITLE
front: add dashboard DL footer

### DIFF
--- a/front/components.d.ts
+++ b/front/components.d.ts
@@ -40,6 +40,7 @@ declare module 'vue' {
     DashboardArcScore: typeof import('./src/components/dashboard/shared/DashboardArcScore.vue')['default']
     DashboardBubbleChart: typeof import('./src/components/dashboard/shared/DashboardBubbleChart.vue')['default']
     DashboardDetailBars: typeof import('./src/components/dashboard/shared/DashboardDetailBars.vue')['default']
+    DashboardFooter: typeof import('./src/components/dashboard/DashboardFooter.vue')['default']
     DashboardGrid: typeof import('./src/components/dashboard/DashboardGrid.vue')['default']
     DashboardHeader: typeof import('./src/components/dashboard/DashboardHeader.vue')['default']
     DashboardNarrative: typeof import('./src/components/dashboard/DashboardNarrative.vue')['default']

--- a/front/src/components/dashboard/DashboardFooter.vue
+++ b/front/src/components/dashboard/DashboardFooter.vue
@@ -1,0 +1,43 @@
+<script lang="ts" setup>
+import AppButton from "@/components/shared/AppButton.vue"
+
+const exportToPdf = () => {
+  window.print()
+}
+</script>
+
+<template>
+  <footer
+    class="flex flex-col items-center gap-4 p-6 rounded-xl bg-primary-50 border border-primary-100 mt-4 print:hidden"
+  >
+    <div class="text-center">
+      <h2 class="text-lg font-bold text-gray-900">Exporter le rapport</h2>
+      <p class="text-sm text-gray-600 mt-1">
+        Téléchargez ce tableau de bord au format PDF pour le partager ou le consulter hors ligne.
+      </p>
+    </div>
+    <AppButton variant="primary" size="lg" @click="exportToPdf">
+      <template #icon-left>
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          width="18"
+          height="18"
+        >
+          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+          <polyline points="7 10 12 15 17 10"></polyline>
+          <line x1="12" y1="15" x2="12" y2="3"></line>
+        </svg>
+      </template>
+      Télécharger le rapport complet
+    </AppButton>
+  </footer>
+</template>
+
+<style scoped>
+@reference "@/styles/main.css";
+</style>

--- a/front/src/components/dashboard/DashboardNarrative.vue
+++ b/front/src/components/dashboard/DashboardNarrative.vue
@@ -9,6 +9,7 @@ import SurfaceTypeWidget from "@/components/dashboard/widgets/SurfaceTypeWidget.
 import VegetationSurfaceWidget from "@/components/dashboard/widgets/VegetationSurfaceWidget.vue"
 import BuildingCharacteristicsWidget from "@/components/dashboard/widgets/BuildingCharacteristicsWidget.vue"
 import { useDashboardStore } from "@/stores/dashboard"
+import DashboardFooter from "@/components/dashboard/DashboardFooter.vue"
 
 const store = useDashboardStore()
 
@@ -111,6 +112,8 @@ const riskInterpretation = computed(() => {
       <PlantabilityWidget :data="store.dashboardData!.plantability" />
     </NarrativeSection>
 
+    <hr class="border-gray-400" />
+
     <NarrativeSection
       section-number="02"
       title="Végétation et biodiversité"
@@ -124,6 +127,8 @@ const riskInterpretation = computed(() => {
       <VegetationSurfaceWidget :data="store.dashboardData!.vegetation" />
       <BiosphereWidget :data="store.dashboardData!.biosphere" />
     </NarrativeSection>
+
+    <hr class="border-gray-400" />
 
     <NarrativeSection
       section-number="03"
@@ -142,6 +147,8 @@ const riskInterpretation = computed(() => {
       <SurfaceTypeWidget :data="store.dashboardData!.lcz" />
     </NarrativeSection>
 
+    <hr class="border-gray-400" />
+
     <NarrativeSection
       section-number="04"
       title="Risques et vulnérabilités"
@@ -154,5 +161,7 @@ const riskInterpretation = computed(() => {
     >
       <HeatWidget :data="store.dashboardData!.vulnerability" />
     </NarrativeSection>
+
+    <DashboardFooter />
   </div>
 </template>

--- a/front/src/components/dashboard/NarrativeSection.vue
+++ b/front/src/components/dashboard/NarrativeSection.vue
@@ -27,7 +27,10 @@ defineProps<Props>()
       <p v-if="finding" class="text-3xl font-bold text-primary-600 tabular-nums mt-1 leading-tight">
         {{ finding }}
       </p>
-      <p v-if="interpretation" class="text-sm font-semibold text-gray-800 leading-relaxed">
+      <p
+        v-if="interpretation"
+        class="text-base font-semibold text-gray-800 leading-relaxed max-w-[68.75%]"
+      >
         {{ interpretation }}
       </p>
       <p v-if="description" class="text-sm text-gray-600 leading-relaxed">{{ description }}</p>

--- a/front/src/components/dashboard/NarrativeSection.vue
+++ b/front/src/components/dashboard/NarrativeSection.vue
@@ -32,7 +32,7 @@ defineProps<Props>()
       </p>
       <p v-if="description" class="text-sm text-gray-600 leading-relaxed">{{ description }}</p>
     </div>
-    <div class="grid grid-cols-1 gap-4 md:grid-cols-2 md:gap-6">
+    <div class="widgets-grid">
       <slot />
     </div>
     <p v-if="source" class="text-xs text-gray-600 italic border-t border-gray-100 pt-3">
@@ -49,3 +49,21 @@ defineProps<Props>()
     </p>
   </section>
 </template>
+
+<style scoped>
+.widgets-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.5rem;
+}
+
+.widgets-grid > :deep(:only-child) {
+  grid-column: 1 / -1;
+}
+
+@media (max-width: 767px) {
+  .widgets-grid {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/front/src/components/dashboard/widgets/HeatWidget.vue
+++ b/front/src/components/dashboard/widgets/HeatWidget.vue
@@ -220,7 +220,7 @@ function drawSpiderChart(
       .append("text")
       .attr("text-anchor", anchor)
       .attr("dominant-baseline", baseline)
-      .attr("font-size", "9px")
+      .attr("font-size", "12px")
       .attr("fill", "#9CA3AF")
 
     axis.lines.forEach((line, lineIndex) => {
@@ -236,7 +236,7 @@ function drawSpiderChart(
       .attr("text-anchor", anchor)
       .attr("dominant-baseline", baseline)
       .attr("dy", `${axis.lines.length * 1.2}em`)
-      .attr("font-size", "10px")
+      .attr("font-size", "15px")
       .attr("font-weight", "600")
       .attr("fill", "#374151")
       .text(`${axis.value.toFixed(1)}/${POLAR_MAX_SCORE}`)
@@ -289,7 +289,7 @@ const { svgRef: nightSvgRef } = useD3Chart(
             :color="HEAT_COLORS.day.accent"
             :max-value="VULNERABILITY_MAX_SCORE"
             :value="props.data.averageDay"
-            :size="90"
+            :size="180"
           />
         </div>
         <div class="score-block">
@@ -298,7 +298,7 @@ const { svgRef: nightSvgRef } = useD3Chart(
             :color="HEAT_COLORS.night.accent"
             :max-value="VULNERABILITY_MAX_SCORE"
             :value="props.data.averageNight"
-            :size="90"
+            :size="180"
           />
         </div>
       </div>
@@ -355,7 +355,8 @@ const { svgRef: nightSvgRef } = useD3Chart(
 }
 
 .scores-col {
-  @apply flex flex-col gap-6 items-center justify-center shrink-0;
+  @apply flex flex-col gap-6 items-center justify-center;
+  flex: 1;
 }
 
 .score-block {
@@ -363,11 +364,12 @@ const { svgRef: nightSvgRef } = useD3Chart(
 }
 
 .score-mode-label {
-  @apply text-xs font-medium text-gray-500;
+  @apply text-lg font-medium text-gray-500;
 }
 
 .spiders-col {
-  @apply flex-1 flex flex-row gap-2 items-start;
+  @apply flex flex-row gap-2 items-start;
+  flex: 2;
 }
 
 .spider-block {
@@ -375,7 +377,7 @@ const { svgRef: nightSvgRef } = useD3Chart(
 }
 
 .spider-mode-label {
-  @apply text-xs font-medium text-gray-500;
+  @apply text-lg font-medium text-gray-500;
 }
 
 .spider-wrapper {

--- a/front/src/components/dashboard/widgets/SurfaceTypeWidget.vue
+++ b/front/src/components/dashboard/widgets/SurfaceTypeWidget.vue
@@ -122,8 +122,8 @@ const { svgRef } = useD3Chart(
 
 .donut-wrapper {
   @apply relative flex items-center justify-center shrink-0;
-  width: 120px;
-  height: 120px;
+  width: 160px;
+  height: 160px;
 }
 
 .donut-center {

--- a/front/src/styles/main.css
+++ b/front/src/styles/main.css
@@ -490,3 +490,22 @@
 .legend-item-label {
   @apply text-sm text-primary-900;
 }
+
+@media print {
+  .sidebar,
+  .mobile-bottom-bar,
+  .back-to-map,
+  .header-controls {
+    display: none !important;
+  }
+
+  .dashboard-view-wrapper {
+    margin-left: 0 !important;
+  }
+
+  .dashboard-content {
+    padding: 1.5rem !important;
+    background: white !important;
+    overflow: visible !important;
+  }
+}


### PR DESCRIPTION
Petites retouches après des retours de Geoffrey

Top ! Je ne sais pas la quantité de temps que tu doi sencore passer sur le dashboard, quelques idées en vrac  :

proposer un téléchargement en PDF (webtoprint mon amour → https://sarahgarcin.com/workshops/article-webtoprint/toolkit.html ) j'avais mis ça en bas de ma demo : https://geoffreydorne.com/tl/dash/
avec des hr pour séparer les 4 grandes catégories
et quand le bloc est tout seul le mettre en fullwidth


Sinon trop bien encore une fois :slightly_smiling_face: