### PR TITLE
feat(front): allow 3D display of vegestrate height raster

### DIFF
--- a/back/api/tests/test_vegetation_height_views.py
+++ b/back/api/tests/test_vegetation_height_views.py
@@ -60,6 +60,24 @@ class VegetationHeightTileViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response["content-type"], "image/png")
 
+    def test_kind_raw_outside_raster_encodes_nodata(self):
+        outside_url = reverse("vegetation-height-tile", kwargs={"z": 1, "x": 0, "y": 0})
+        with self.settings(MEDIA_ROOT=self.tmpdir):
+            response = self.client.get(outside_url, {"kind": "raw"})
+        self.assertEqual(response.status_code, 200)
+
+        img = Image.open(io.BytesIO(response.content))
+        pixels = np.asarray(img).reshape(-1, 4)
+        # Fully transparent pixels would decode to -32768 m and extrude as a crater.
+        self.assertTrue((pixels[:, 3] == 255).all())
+        heights = (
+            pixels[:, 0].astype(float) * 256
+            + pixels[:, 1]
+            + pixels[:, 2].astype(float) / 256
+            - 32768
+        )
+        self.assertTrue((heights == -1).all())
+
     def test_missing_raster_returns_404(self):
         with self.settings(MEDIA_ROOT=tempfile.mkdtemp()):
             response = self.client.get(self.tile_url)

--- a/back/api/views/vegetation_height_views.py
+++ b/back/api/views/vegetation_height_views.py
@@ -70,7 +70,7 @@ class VegetationHeightTileView(APIView):
                     or top < raster_bounds.bottom
                     or bottom > raster_bounds.top
                 ):
-                    return self._empty_tile()
+                    return self._empty_tile(kind)
 
                 try:
                     window = from_bounds(
@@ -103,11 +103,11 @@ class VegetationHeightTileView(APIView):
 
                 except Exception:
                     logger.exception("Window error for tile %s/%s/%s", z, x, y)
-                    return self._empty_tile()
+                    return self._empty_tile(kind)
 
         except Exception:
             logger.exception("Error generating vegetation tile %s/%s/%s", z, x, y)
-            return self._empty_tile()
+            return self._empty_tile(kind)
 
     @staticmethod
     def _encode_terrarium(data, nodata, rgba_data):
@@ -125,9 +125,14 @@ class VegetationHeightTileView(APIView):
         rgba_data[..., 2] = ((shifted % 1) * 256).astype(np.uint8)
         rgba_data[..., 3] = 255
 
-    def _empty_tile(self):
-        """Return a transparent 256x256 PNG."""
-        img = Image.new("RGBA", (256, 256), (0, 0, 0, 0))
+    def _empty_tile(self, kind="class"):
+        """Return a 256x256 PNG carrying no data."""
+        if kind == "raw":
+            rgba_data = np.zeros((256, 256, 4), dtype=np.uint8)
+            self._encode_terrarium(np.full((256, 256), NODATA_HEIGHT), None, rgba_data)
+            img = Image.fromarray(rgba_data, mode="RGBA")
+        else:
+            img = Image.new("RGBA", (256, 256), (0, 0, 0, 0))
         buffer = io.BytesIO()
         img.save(buffer, format="PNG")
         buffer.seek(0)

--- a/front/src/stores/map.ts
+++ b/front/src/stores/map.ts
@@ -34,6 +34,7 @@ import { CLIMATE_ZONE_MAP_COLOR_MAP } from "@/utils/climateZone"
 import {
   VEGESTRATE_COLOR_MAP,
   VEGESTRATE_HEIGHT_MAP,
+  VEGESTRATE_TERRAIN_EXAGGERATION,
   buildElevationColorRamp,
   normalizeHeightRanges,
   type HeightRange
@@ -171,6 +172,9 @@ export const useMapStore = defineStore("map", () => {
     return DataTypeToGeolevel[selectedDataType.value!]
   }
 
+  const isVegestrateHeightMode = (datatype: DataType) =>
+    datatype === DataType.VEGESTRATE && showVegestrateHeight.value
+
   /**
    * Deep-clone the raw maplibre style JSON for a given MapStyle, inject the
    * backend base URL where needed and apply centralized source attributions.
@@ -231,7 +235,7 @@ export const useMapStore = defineStore("map", () => {
   ): AddLayerObject[] => {
     const layerId = getLayerId(datatype, geolevel)
 
-    if (datatype === DataType.VEGESTRATE && showVegestrateHeight.value) {
+    if (isVegestrateHeightMode(datatype)) {
       return [
         {
           id: layerId,
@@ -507,7 +511,7 @@ export const useMapStore = defineStore("map", () => {
       map.off("zoom", heightMapZoomHandler.value)
       heightMapZoomHandler.value = null
     }
-    if (datatype === DataType.VEGESTRATE && showVegestrateHeight.value) {
+    if (isVegestrateHeightMode(datatype)) {
       const handler = async (e: any) => {
         if (selectionMode.value !== SelectionMode.POINT) return
         clickCoordinates.value = { lat: e.lngLat.lat, lng: e.lngLat.lng }
@@ -585,7 +589,7 @@ export const useMapStore = defineStore("map", () => {
     const fullBaseApiUrl = getFullBaseApiUrl()
     const sourceId = getSourceId(datatype, geolevel)
 
-    if (datatype === DataType.VEGESTRATE && showVegestrateHeight.value) {
+    if (isVegestrateHeightMode(datatype)) {
       const tileUrl = `${fullBaseApiUrl}/tiles/vegetation-height/{z}/{x}/{y}.png?kind=raw`
       map.addSource(sourceId, {
         type: "raster-dem",
@@ -664,6 +668,7 @@ export const useMapStore = defineStore("map", () => {
       }
       // remove existing layers and sources
       if (previousDataType !== null) {
+        clearTerrain(mapInstance)
         const layerId = getLayerId(previousDataType, previousGeoLevel)
         if (mapInstance.getLayer(layerId)) {
           mapInstance.removeLayer(layerId)
@@ -743,6 +748,7 @@ export const useMapStore = defineStore("map", () => {
     Object.keys(mapInstancesByIds.value).forEach((mapId) => {
       const mapInstance = mapInstancesByIds.value[mapId]
       removeControls(mapInstance)
+      clearTerrain(mapInstance)
       // Clear overlay layers before style change
       if (mapInstance.getLayer("qpv-border")) {
         removeQPVLayer(mapInstance)
@@ -777,13 +783,27 @@ export const useMapStore = defineStore("map", () => {
     })
   }
 
+  const applyVegestrateTerrain = (mapInstance: Map, datatype: DataType) => {
+    if (!isVegestrateHeightMode(datatype) || !use3D.value) return
+    const sourceId = getSourceId(datatype, DataTypeToGeolevel[datatype])
+    if (!mapInstance.getSource(sourceId)) return
+    mapInstance.setTerrain({ source: sourceId, exaggeration: VEGESTRATE_TERRAIN_EXAGGERATION })
+    console.info("cypress: vegestrate terrain enabled")
+  }
+
+  const clearTerrain = (mapInstance: Map) => {
+    if (!mapInstance.getTerrain()) return
+    mapInstance.setTerrain(null)
+    console.info("cypress: vegestrate terrain disabled")
+  }
+
   const initTiles = (mapInstance: Map) => {
     const currentGeoLevel = getGeoLevelFromDataType()
     setupSource(mapInstance, selectedDataType.value!, currentGeoLevel)
     setupTile(mapInstance, selectedDataType.value!, currentGeoLevel)
+    applyVegestrateTerrain(mapInstance, selectedDataType.value!)
   }
 
-  // TODO: display loading during the async execution
   const addQPVLayer = async (mapInstance: Map) => {
     if (!mapInstance.getSource("qpv-source")) {
       const data = await getQPVData()
@@ -1113,9 +1133,6 @@ export const useMapStore = defineStore("map", () => {
     selectedDataType.value = initialDatatype
     controlsAdded.value[mapId] = false
 
-    // markRaw: a reactive proxy around a maplibre Map breaks paint updates.
-    // Style expressions read Color.rgb, a non-writable non-configurable property,
-    // and a proxy cannot report the raw value for it (TypeError inside the render loop).
     mapInstancesByIds.value[mapId] = markRaw(
       new Map({
         container: mapId,
@@ -1132,9 +1149,6 @@ export const useMapStore = defineStore("map", () => {
       setupControls(mapInstance)
       initTiles(mapInstance)
       shapeDrawing.initDraw(mapInstance)
-      // The backend score is only queried once the shape is finished (and on
-      // subsequent edits of that finished shape). While the shape is still being
-      // drawn, only the client-side area is refreshed — no request is fired.
       shapeDrawing.onShapeFinished(() => {
         markShapeFinished()
         recomputeLiveArea()
@@ -1146,8 +1160,6 @@ export const useMapStore = defineStore("map", () => {
           requestScoreIfWithinLimit()
         }
       })
-      // Idempotent registration (mirrors setupClickEventOnTile): remove any prior
-      // listener before re-adding so re-initialisation never stacks handlers.
       mapInstance.off("click", handleEditingMapClick)
       mapInstance.on("click", handleEditingMapClick)
       mapInstance.once("render", () => {
@@ -1179,13 +1191,10 @@ export const useMapStore = defineStore("map", () => {
   const changeSelectionMode = (mode: SelectionMode) => {
     selectionMode.value = mode
 
-    // Clear contextual data when changing mode
     contextData.removeData()
 
-    // Use Terra Draw to change mode
     shapeDrawing.setMode(mode)
 
-    // In POINT mode (simple click), disable drawing
     if (mode === SelectionMode.POINT) {
       shapeDrawing.stopDrawing()
     }
@@ -1194,26 +1203,21 @@ export const useMapStore = defineStore("map", () => {
   const MIN_LOADING_DURATION_MS = 500
 
   const performCalculation = async () => {
-    // Activate loading state
     isCalculating.value = true
     contextData.error.value = false
     const loadingStartTime = Date.now()
 
     try {
-      // Retrieve aggregated scores in shape via backend API
       const scores = await shapeDrawing.getScoresInShape(selectedDataType.value!)
 
       if (scores) {
-        // Set aggregated scores directly in context
         contextData.data.value = scores
       }
     } catch (e) {
-      // Surface the failure instead of silently leaving an empty panel.
       console.error("Error retrieving scores in shape:", e)
       contextData.data.value = null
       contextData.error.value = true
     } finally {
-      // Ensure minimum loading duration of 0.5 seconds
       const loadingDuration = Date.now() - loadingStartTime
       if (loadingDuration < MIN_LOADING_DURATION_MS) {
         await new Promise((resolve) =>
@@ -1224,7 +1228,6 @@ export const useMapStore = defineStore("map", () => {
     }
   }
 
-  // Debounce calculation to avoid multiple rapid calls
   const finishShapeSelection = useDebounceFn(performCalculation, 500, { maxWait: 1000 })
 
   const isShapeMode = computed(() => selectionMode.value !== SelectionMode.POINT)
@@ -1243,8 +1246,6 @@ export const useMapStore = defineStore("map", () => {
     return { type: "Polygon", coordinates: [ring as [number, number][]] }
   }
 
-  // Retry path differs by mode: a shape error re-runs the polygon calculation,
-  // a tile error replays the last tile request.
   const retryContextData = () => {
     if (isShapeMode.value) {
       performCalculation()
@@ -1267,8 +1268,6 @@ export const useMapStore = defineStore("map", () => {
     () => liveArea.value !== null && liveArea.value > MAX_SHAPE_AREA_M2
   )
 
-  // Query the backend only for selections within the allowed size, so oversized
-  // shapes never reach the server. A too-large shape clears any stale result.
   const requestScoreIfWithinLimit = () => {
     if (isAreaTooLarge.value) {
       contextData.removeData()
@@ -1277,8 +1276,6 @@ export const useMapStore = defineStore("map", () => {
     }
   }
 
-  // Shared reset for both shape-session entry points (start from POINT vs. restart
-  // from EDITING). Kept as distinct public methods so call sites read by intent.
   const resetToDrawingState = (mode: SelectionMode) => {
     shapeEditing.value = false
     liveArea.value = null
@@ -1293,13 +1290,8 @@ export const useMapStore = defineStore("map", () => {
     shapeEditing.value = true
   }
 
-  // Distance (screen px) a click must clear the current shape by before it counts
-  // as a "new zone" rather than an attempt to edit the shape.
   const REDRAW_MARGIN_PX = 24
 
-  // While editing, a click clearly away from the finished shape starts a fresh shape
-  // of the same type (discarding the previous one). Clicks on/near the shape are left
-  // to Terra Draw for vertex/feature editing, so a near-miss never destroys the shape.
   const handleEditingMapClick = (e: { point: { x: number; y: number } }) => {
     if (drawingState.value !== "editing") return
     const map = mapInstancesByIds.value["default"]
@@ -1336,6 +1328,13 @@ export const useMapStore = defineStore("map", () => {
       }
     })
     refreshLayers()
+    Object.values(mapInstancesByIds.value).forEach((mapInstance) => {
+      if (use3D.value) {
+        applyVegestrateTerrain(mapInstance, selectedDataType.value!)
+      } else {
+        clearTerrain(mapInstance)
+      }
+    })
   }
 
   const zoomTo = (targetZoom: number) => {

--- a/front/src/utils/vegetation.ts
+++ b/front/src/utils/vegetation.ts
@@ -77,6 +77,7 @@ export const STRATE_GRADIENT_CSS = `linear-gradient(to top, ${Object.values(STRA
   .join(", ")})`
 
 const ELEVATION_MAX = 40
+export const VEGESTRATE_TERRAIN_EXAGGERATION = 2
 export const ELEVATION_BINS = [
   { min: 0, color: "#ecdeb1" },
   { min: 1, color: "#e6dcac" },


### PR DESCRIPTION
Utilisation directe du `raster-dem` comme `terrain` pour Maplibre quand le bouton 3D est cliqué 